### PR TITLE
Changed the default syntax from R to R Console.

### DIFF
--- a/config/R/Main.sublime-menu
+++ b/config/R/Main.sublime-menu
@@ -28,7 +28,7 @@
                     "suppress_echo": {"osx": true,
                                       "linux": true,
                                       "windows": false},
-                    "syntax": "Packages/R/R.tmLanguage"
+                    "syntax": "Packages/R/R Console.tmLanguage"
                     }
                 }
             ]


### PR DESCRIPTION
The REPL R terminal uses R (script) as the default syntax, which uses a lot of color, often unnecessarily. It seems more fitting to use the R Console in this case, leaving the R syntax for the user script files.
