### PR TITLE
Some conveniences

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -14,9 +14,47 @@
 	{ "keys": ["enter"], "command": "repl_enter", "args": {},
 	"context":
 		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true },
+			{ "key": "auto_complete_visible", "operator": "equal", "operand": false }
+		]
+	},
+	{ "keys": ["escape"], "command": "repl_escape", "args": {},
+	"context":
+		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true }
+		]
+	},
+	{ "keys": ["backspace"], "command": "repl_backspace", "args": {},
+	"context":
+		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true }
+		]
+	},
+	{ "keys": ["left"], "command": "repl_left", "args": {},
+	"context":
+		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true }
+		]
+	},
+	{ "keys": ["home"], "command": "repl_home", "args": {},
+	"context":
+		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true }
+		]
+	},
+	{ "keys": ["shift+left"], "command": "repl_shift_left", "args": {},
+	"context":
+		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true }
+		]
+	},
+	{ "keys": ["shift+home"], "command": "repl_shift_home", "args": {},
+	"context":
+		[
 			{ "key": "setting.repl", "operator": "equal", "operand": true }
 		]
 	}
+
 
 	//{ "keys": ["f2", "s"], "command": "repl_transfer_current", "args": {"scope": "selection"}},
 	//{ "keys": ["shift+f2", "s"], "command": "repl_transfer_current", "args": {"scope": "selection", "action":"view_write"}},

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -14,9 +14,47 @@
 	{ "keys": ["enter"], "command": "repl_enter", "args": {},
 	"context":
 		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true },
+			{ "key": "auto_complete_visible", "operator": "equal", "operand": false }
+		]
+	},
+	{ "keys": ["escape"], "command": "repl_escape", "args": {},
+	"context":
+		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true }
+		]
+	},
+	{ "keys": ["backspace"], "command": "repl_backspace", "args": {},
+	"context":
+		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true }
+		]
+	},
+	{ "keys": ["left"], "command": "repl_left", "args": {},
+	"context":
+		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true }
+		]
+	},
+	{ "keys": ["home"], "command": "repl_home", "args": {},
+	"context":
+		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true }
+		]
+	},
+	{ "keys": ["shift+left"], "command": "repl_shift_left", "args": {},
+	"context":
+		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true }
+		]
+	},
+	{ "keys": ["shift+home"], "command": "repl_shift_home", "args": {},
+	"context":
+		[
 			{ "key": "setting.repl", "operator": "equal", "operand": true }
 		]
 	}
+	
 
 	//{ "keys": ["f2", "s"], "command": "repl_transfer_current", "args": {"scope": "selection"}},
 	//{ "keys": ["shift+f2", "s"], "command": "repl_transfer_current", "args": {"scope": "selection", "action":"view_write"}},

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -14,6 +14,43 @@
 	{ "keys": ["enter"], "command": "repl_enter", "args": {},
 	"context":
 		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true },
+			{ "key": "auto_complete_visible", "operator": "equal", "operand": false }
+		]
+	},
+	{ "keys": ["escape"], "command": "repl_escape", "args": {},
+	"context":
+		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true }
+		]
+	},
+	{ "keys": ["backspace"], "command": "repl_backspace", "args": {},
+	"context":
+		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true }
+		]
+	},
+	{ "keys": ["left"], "command": "repl_left", "args": {},
+	"context":
+		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true }
+		]
+	},
+	{ "keys": ["home"], "command": "repl_home", "args": {},
+	"context":
+		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true }
+		]
+	},
+	{ "keys": ["shift+left"], "command": "repl_shift_left", "args": {},
+	"context":
+		[
+			{ "key": "setting.repl", "operator": "equal", "operand": true }
+		]
+	},
+	{ "keys": ["shift+home"], "command": "repl_shift_home", "args": {},
+	"context":
+		[
 			{ "key": "setting.repl", "operator": "equal", "operand": true }
 		]
 	}


### PR DESCRIPTION
Namely:
- When cursor is between end of output and end of file, some shortcuts
  start behave differently:
  1) Enter commences from wherever.
  2) Escape cleans the input.
  3) Movements to the left (left, shift+left, home, shift+home, backspace)
  start treating end of output like beginning of file. One can still use
  other movement keys or mouse to escape from this virtual wall.
- Special treatment of the "cls" command (probably, should be configurable).
- REPL history navigation automatically scrolls the view to make
  the input visible.

Also:
- Added the "repl_kill" command to enable Ctrl+C-ing.
- Added "repl_external_id" to view settings.
- Added "view_id" parameter to "repl_open", so that one can reuse the same
  REPL view multiple times (e.g. to re-launch an interpreter after ctrl+c).
