### PR TITLE
Updated config/NodeJS/repl.js to comply with Node.js 0.8.x repl module s...

### DIFF
--- a/config/NodeJS/repl.js
+++ b/config/NodeJS/repl.js
@@ -1,12 +1,13 @@
-(function(){
-	var options = {
-		prompt:     null, //'> ',
-		source:     null, //process.stdin,
-		eval:       null, //require('vm').runInThisContext,
-		useGlobal:  true  //false
-	};
+(function () {
 
-	var repl = require('repl');
-	repl.disableColors = true;
-	repl.start(options.prompt, options.source, options.eval, options.useGlobal);
+    var repl = require('repl');
+    
+    repl.start({
+        prompt:    null, //'> ',
+        source:    null, //process.stdin,
+        eval:      null, //require('vm').runInThisContext,
+        useGlobal: true, //false
+        useColors: false
+    });
+
 })();


### PR DESCRIPTION
I've updated the NodeJS/repl.js configuration script to function with Node.js 0.8.x. Due to the deprecated syntax in the file the REPL refused to launch prior to these changes.

This solves [issue #51](https://github.com/wuub/SublimeREPL/issues/51).
