### PR TITLE
Adds the Tower.js console

### DIFF
--- a/config/Tower/Default.sublime-commands
+++ b/config/Tower/Default.sublime-commands
@@ -1,0 +1,10 @@
+[
+    {
+        "caption": "SublimeREPL: Tower Console",
+        "command": "run_existing_window_command", "args":
+        {
+            "id": "repl_tower",
+            "file": "config/Tower/Main.sublime-menu"
+        }
+    }
+]

--- a/config/Tower/Main.sublime-menu
+++ b/config/Tower/Main.sublime-menu
@@ -1,0 +1,27 @@
+[
+     {
+        "id": "tools",
+        "children":
+        [{
+            "caption": "SublimeREPL",
+            "mnemonic": "r",
+            "id": "SublimeREPL",
+            "children":
+            [
+                {"command": "repl_open", 
+                "id": "repl_tower",
+                 "caption": "Tower Console",
+                 "args": {
+                    "cwd": "$project_path",               
+                    "type": "subprocess",
+                    "encoding": "utf8",
+                    "cmd": ["tower", "console", "-c"],    
+                    "syntax": "Packages/CoffeeScript/CoffeeScript.tmLanguage",
+                    "external_id": "tower",
+                    "extend_env": {"NODE_DISABLE_COLORS": "1"}
+                    }
+                }
+            ]   
+        }]
+    }
+]


### PR DESCRIPTION
Tower.js ( https://github.com/viatropos/tower )  is a framework for the Node.js environment. It is an MVC framework, loosely modeled on Rails, but with all the capabilities of node. I'm not sure if you are interested in supporting consoles for frameworks or not, but I believe this will be very useful to people developing with Tower. 
