### PR TITLE
Remove any character that precedes backspace (\08)

### DIFF
--- a/sublimerepl.py
+++ b/sublimerepl.py
@@ -250,7 +250,7 @@ class ReplView(object):
         # remove color codes
         if self._filter_color_codes:
             unistr = re.sub(r'\033\[\d*(;\d*)?\w', '', unistr)
-            unistr = re.sub(r'_\x08', '', unistr)
+            unistr = re.sub(r'.\x08', '', unistr)
 
         # string is assumet to be already correctly encoded
         v = self._view


### PR DESCRIPTION
When filtering ASCII color codes, remove _any_ character that precedes a
backspace control character from the output, not just underscores.  Matlab likes littering its output with random characters that it then deletes.  I haven't tried all the REPLs, but I this that it's a pretty safe bet that characters preceding backspace control codes should be removed.
