### PR TITLE
Change name of Gauche syntax dir

### DIFF
--- a/config/Scheme/Main.sublime-menu
+++ b/config/Scheme/Main.sublime-menu
@@ -45,7 +45,7 @@
                         "cwd": "$folder",
                         "cmd_postfix": "\n",
                         "extend_env": {"INSIDE_EMACS": "1"},
-                        "syntax": "Packages/Sublime-Gauche-Syntax/Gauche.tmLanguage"
+                        "syntax": "Packages/Gauche/Gauche.tmLanguage"
                         }
                     }
                 ]}


### PR DESCRIPTION
Since Gauche syntax has merged to Package Control as "Gauche".
