### PR TITLE
Fixing autocomplete for Node.JS

### DIFF
--- a/config/NodeJS/repl.js
+++ b/config/NodeJS/repl.js
@@ -21,6 +21,10 @@
         var index = strData.indexOf(":");
         var json = strData.slice(index+1, strData.length - 1)
         var inData = JSON.parse(json);
+        var wordIndex = inData.line.slice(inData.cursor_pos).search(/\b/);
+        if(wordIndex !== 0){
+            inData.line = inData.line.slice(0, inData.cursor_pos);
+        }
 
         var send = function (_, completions) {
             var comps = completions[0];


### PR DESCRIPTION
Node now gets a string extracted from the begging until the caret; now it returns relevant auto-complete suggestions where it previously did not.
