### PR TITLE
Fixed REPL evaluation shortcuts

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -115,12 +115,12 @@
 	},
 
 
-	{ "keys": ["ctrl+,", "s"], "command": "repl_transfer_current", "args": {"scope": "selection"}},
-	{ "keys": ["ctrl+shift+,", "s"], "command": "repl_transfer_current", "args": {"scope": "selection", "action":"view_write"}},
-	{ "keys": ["ctrl+,", "f"], "command": "repl_transfer_current", "args": {"scope": "file"}},
-	{ "keys": ["shift+ctrl+,", "f"], "command": "repl_transfer_current", "args": {"scope": "file", "action":"view_write"}},
-	{ "keys": ["ctrl+,", "l"], "command": "repl_transfer_current", "args": {"scope": "lines"}},
-	{ "keys": ["shift+ctrl+,", "l"], "command": "repl_transfer_current", "args": {"scope": "lines", "action":"view_write"}},
-	{ "keys": ["ctrl+,", "b"], "command": "repl_transfer_current", "args": {"scope": "block"}},
-	{ "keys": ["shift+ctrl+,", "b"], "command": "repl_transfer_current", "args": {"scope": "block", "action":"view_write"}}
+	{ "keys": ["ctrl+s"], "command": "repl_transfer_current", "args": {"scope": "selection"}},
+	{ "keys": ["ctrl+shift+s"], "command": "repl_transfer_current", "args": {"scope": "selection", "action":"view_write"}},
+	{ "keys": ["ctrl+f"], "command": "repl_transfer_current", "args": {"scope": "file"}},
+	{ "keys": ["shift+ctrl+f"], "command": "repl_transfer_current", "args": {"scope": "file", "action":"view_write"}},
+	{ "keys": ["ctrl+l"], "command": "repl_transfer_current", "args": {"scope": "lines"}},
+	{ "keys": ["shift+ctrl+l"], "command": "repl_transfer_current", "args": {"scope": "lines", "action":"view_write"}},
+	{ "keys": ["ctrl+b"], "command": "repl_transfer_current", "args": {"scope": "block"}},
+	{ "keys": ["shift+ctrl+b"], "command": "repl_transfer_current", "args": {"scope": "block", "action":"view_write"}}
 ]


### PR DESCRIPTION
The REPL evaluation shortcuts were not working for me on OS X Lion. I set the REPL evaluation shortcuts to plain ["key+key"] format.
