### PR TITLE
Uncapitalized the external_id value for Clisp repl

### DIFF
--- a/config/Clisp/Main.sublime-menu
+++ b/config/Clisp/Main.sublime-menu
@@ -17,7 +17,7 @@
                     "cmd": ["clisp", "-disable-readline"],
                     "cwd": "$file_path",
                     "syntax": "Packages/Lisp/Lisp.tmLanguage",
-                    "external_id": "Lisp"
+                    "external_id": "lisp"
                     }
                 }
             ]


### PR DESCRIPTION
Using the "eval in" and "transfer to" commands with the Clisp repl weren't working for me until I uncapitalized this. After uncapitalizing the external_id and restarting the repl, they worked fine. Switching it back to a capital `Lisp` and restarting the repl broke it again.

This seems to be the problem that we discussed previously on Twitter about the source file's language scope and the external_id of the repl having to match, as seen in https://github.com/wuub/SublimeREPL/blob/master/text_transfer.py#L77

For what it's worth, my file was using the default Lisp syntax mode, and had the extension `.lisp`. 
