### PR TITLE
Added: getting started and keybindings in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Very basic documentation will soon be available on RTD: [http://sublimerepl.read
 #### Getting started
 
 * Create or open your file with code.
-* Menu/Tools/Command Palete (or Mac OS X: `⇧⌘P`) 
-then type "SublimeREPL" and select the approperiate language
-* Menu/View/Layout/Rows: 2 (or Mac OS X: `⌥⇧⌘2`)
-* Menu/View/Move File to Group/Group 2 (or: `⌃⇧2`)
+* Menu / Tools / Command Palette (OS X: `⇧⌘P`) 
+then type "SublimeREPL" and select the approperiate language.
+* Menu / View / Layout / Rows: 2 (OS X: `⌥⇧⌘2`).
+* Menu / View / Move File to Group / Group 2 (`⌃⇧2`).
 
 #### Keybindings
 


### PR DESCRIPTION
It would have saved 15min of my time, so I think that it is worth mentioning.

Related:
https://github.com/wuub/SublimeREPL/issues/120

In short, it's adding:
#### Getting started
- Create or open your file with code.
- Menu / Tools / Command Palette (OS X: `⇧⌘P`) 
  then type "SublimeREPL" and select the approperiate language.
- Menu / View / Layout / Rows: 2 (OS X: `⌥⇧⌘2`).
- Menu / View / Move File to Group / Group 2 (`⌃⇧2`).
#### Keybindings
- Evaluate in REPL:
  - `⌃+,, s` Selection
  - `⌃+,, f` File  
  - `⌃+,, l` Lines
  - `⌃+,, b` Block
- Transfer in REPL (just copy, without evaluating it):
  - `⌃⇧+,, s` Selection
  - `⌃⇧+,, f` File  
  - `⌃⇧+,, l` Lines
  - `⌃⇧+,, b` Block

Note: `⌃+,, f` means: press Ctrl and Comma, release all, press F.
