### PR TITLE
Fix SML syntax path

### DIFF
--- a/config/SML/Main.sublime-menu
+++ b/config/SML/Main.sublime-menu
@@ -17,7 +17,7 @@
                     "cmd": ["sml"],
                     "cwd": "$file_path",
                     "external_id": "sml",
-                    "syntax": "Packages/SML/SML.tmLanguage"
+                    "syntax": "Packages/SML (Standard ML)/sml.tmLanguage"
                     }
                 }
             ]


### PR DESCRIPTION
Changed the syntax file path for the SML REPL to match the [SML package](https://github.com/seanjames777/SML-Language-Definition) that's in Package Control. 

This will fix (some of) the trouble that @bennlich was having in the comments on #121. 
