### PR TITLE
Use default Lisp external_id and syntax for Scheme repl

### DIFF
--- a/config/Scheme/Main.sublime-menu
+++ b/config/Scheme/Main.sublime-menu
@@ -19,7 +19,7 @@
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
-                        "external_id": "scheme",
+                        "external_id": "lisp",
                         "cmd": {"linux": ["scheme"],
                                 "osx": ["scheme"],
                                 "windows": ["scheme"]},
@@ -27,7 +27,7 @@
                         "cwd": "$folder",
                         "cmd_postfix": "\n",
                         "extend_env": {"INSIDE_EMACS": "1"},
-                        "syntax": "Packages/sublime-scheme-syntax/Scheme.tmLanguage"
+                        "syntax": "Packages/Lisp/Lisp.tmLanguage"
                         }
                     },
                     {"command": "repl_open",


### PR DESCRIPTION
Back when the config for the Scheme repl got merged in from my fork of this repo, I was working on a Scheme syntax package, and the repl depended on that. However, as my sublime-scheme-syntax package isn't ready for prime time yet, it's not currently in Package Control.

As such, for now it seems to make more sense to have the Scheme repl use an `external_id` of `lisp` and to just use the default Lisp syntax. The Common Lisp repl (clisp) does exactly this and works fine.

The only bother is that the `.scm` file extension isn't listed in Packages/Lisp/Lisp.tmLanguage (clisp's `.cl` is). All the user would have to do, however, is manually select the Lisp syntax mode, or simply add `.scm` to the list in Packages/Lisp/Lisp.tmLanguage.

Does all of that make sense?
