### PR TITLE
Adding config option to open Repls in a different view group

### DIFF
--- a/SublimeREPL.sublime-settings
+++ b/SublimeREPL.sublime-settings
@@ -5,6 +5,16 @@
 	// once "PATH": "{PATH}:/home/username/mylocalinstalls/bin" or whatever
 	"default_extend_env": {},
 
+	// Specify whether to move repls to a different Sublime Text group (frame)
+	// immediately on opening. Setting this to true will simply move it to
+	// the 'next' group from the one that was in focus when it was opened
+	// (one down with row layout, one to the right with column and grid
+	// layout). Alternatively, you can set this to the index of the group in
+	// which you want all repls to be opened (index 0 being the top-left group).
+	// Activating this option will NOT automatically change your layout/create
+	// a new group if it isn't open.
+	"open_repl_in_group": false,
+
 	// Persistent history is stored per REPL external_id, it means that all python
 	// REPLS will share history. If you wish you can disable history altogether
 	"persistent_history_enabled": true,

--- a/sublimerepl.py
+++ b/sublimerepl.py
@@ -175,6 +175,31 @@ class ReplView(object):
 
         self._filter_color_codes = settings.get("filter_ascii_color_codes")
 
+
+	# optionally move view to a different group
+
+	# find current position of this replview
+	(group,index) = self._window.get_view_index(view)
+
+	# get the view that was focussed before the repl was opened.
+	# we'll have to focus this one briefly to make sure it's in the 
+	# foreground again after moving the replview away
+	oldview = self._window.views_in_group(group)[max(0,index-1)]
+
+	target = settings.get("open_repl_in_group")
+
+	# either the target group is specified by index
+	if isinstance(target, long):
+		if 0 <= target < self._window.num_groups() and target != group:
+			self._window.set_view_index(view, target, len(self._window.views_in_group(target)))
+			self._window.focus_view(oldview)
+			self._window.focus_view(view)
+	# or, if simply set to true, move it to the next group from the currently active one
+	elif target and group+1 < self._window.num_groups():
+		self._window.set_view_index(view, group+1, len(self._window.views_in_group(group+1)))
+		self._window.focus_view(oldview)
+		self._window.focus_view(view)
+
         # begin refreshing attached view
         self.update_view_loop()
 


### PR DESCRIPTION
I'd often start up a new Repl with a Clojure file in focus (thus automatically loading its dependencies on startup) just to find the Repl sitting on top of the file I was actually working on. I've therefore added a config option which allows you to set the default opening position of new ReplViews to a specific Sublime Text group index or simply to 'one group down'/'one group to the right'.
