### PR TITLE
Adding support for Repls to load files directly from disk

### DIFF
--- a/repls/repl.py
+++ b/repls/repl.py
@@ -56,14 +56,14 @@ class Repl(object):
         return NotImplementedError
 
     def is_alive(self):
-        """ Returns true if the undelying process is stil working"""
+        """Returns True if the underlying process is still working"""
         raise NotImplementedError
 
     def write_bytes(self, bytes):
         raise NotImplementedError
 
     def read_bytes(self):
-        """Reads at lest one byte of Repl output. Returns None if output died.
+        """Reads at least one byte of Repl output. Returns None if output died.
            Can block!!!"""
         raise NotImplementedError
 
@@ -92,3 +92,9 @@ class Repl(object):
                 self.reset_decoder()
             if output:
                 return output
+
+    def is_local(self):
+        """Subclasses for which the Repl runs on the local machine should
+        return True here to signal that 'eval file' can potentially load
+        files directly from disk"""
+        return False

--- a/repls/subprocess_repl.py
+++ b/repls/subprocess_repl.py
@@ -191,3 +191,5 @@ class SubprocessRepl(repl.Repl):
         if self.is_alive():
             self.popen.send_signal(sig)
 
+    def is_local(self):
+        return True

--- a/text_transfer.py
+++ b/text_transfer.py
@@ -55,6 +55,27 @@ def ruby_sender(repl, text, file_name=None):
     return default_sender(repl, payload, file_name)
 
 
+def default_fileloader(repl, text, file_name):
+    # if no specific handler is known simply transfer the file's content to repl
+    SENDERS[repl.external_id](repl, text + repl.cmd_postfix, file_name)
+
+"""FILELOADERS is a dict of functions used to let the repl load a file directly from
+   the disk, rather than copying the entire file contents over"""
+FILELOADERS = defaultdict(lambda: default_fileloader)
+
+def fileloader(external_id,):
+    def wrap(func):
+        FILELOADERS[external_id] = func
+    return wrap
+
+@fileloader("clojure")
+def clojure_fileloader(repl, text, file_name):
+    repl.write("(load-file \"" + str(file_name).replace('"', '\\\"') + "\")" + repl.cmd_postfix)
+
+@fileloader("python")
+def python_fileloader(repl, text, file_name):
+    repl.write("execfile(" + repr(file_name) + ")" + repl.cmd_postfix)
+
 class ReplViewWrite(sublime_plugin.WindowCommand):
     def run(self, external_id, text, file_name=None):
         rv = manager.find_repl(external_id)
@@ -73,6 +94,12 @@ class ReplSend(sublime_plugin.WindowCommand):
             cmd += rv.repl.cmd_postfix
         SENDERS[external_id](rv.repl, cmd, file_name)
 
+class ReplLoadFile(sublime_plugin.WindowCommand):
+    def run(self, external_id, file_name, text, with_auto_postfix=True):
+        rv = manager.find_repl(external_id)
+        if not rv:
+            return
+        FILELOADERS[external_id](rv.repl, text, file_name)
 
 class ReplTransferCurrent(sublime_plugin.TextCommand):
     def run(self, edit, scope="selection", action="send"):
@@ -87,6 +114,9 @@ class ReplTransferCurrent(sublime_plugin.TextCommand):
             text = self.selected_blocks()
         elif scope == "file":
             text = self.selected_file()
+            if action == "send" and self.view.file_name() and not self.view.is_dirty():
+                # try to let the repl load the file externally if it supports it
+                action = "load_file"
         cmd = "repl_" + action
         self.view.window().run_command(cmd, {"external_id": self.repl_external_id(), "text": text, "file_name": self.view.file_name()})
 


### PR DESCRIPTION
Up until now "Eval file in repl" would simply send the current file's contents to the repl, adding a command-postfix. If something goes wrong this can lead to not very useful error messages like this:

```
CompilerException java.lang.RuntimeException: Unable to resolve symbol: foo in this context, compiling:(NO_SOURCE_PATH:1927)
```

Even worse, when there's a syntax problem the repl might be waiting for more input and become unresponsive, as is the case when you load a lisp file with an unmatched parens a la

```
(foo
```

which would simply block the repl without a message until the user enters a ")", which results in delayed execution or an error message.

A better approach seems to be using language-specific load commands (Python's execfile(), Clojure's (load-file) etc). Probably the best way to do this would be by adding a load_file() method to the Repl-class, but this would also lead to a lot of overhead in terms of creating new subclasses. So instead I duplicated the SENDERS infrastructure in text_transfer.py to add custom FILELOADERS for different languages, defaulting to the old approach of just sending the file's contents to the repl. So far I've only added custom treatments for Clojure and Python but adding new ones is easy, the only thing that has to be watched out for is how filenames have to be escaped differently for different languages. That's what the above error message looks like now:

```
CompilerException java.lang.RuntimeException: Unable to resolve symbol: foo in this context, compiling:(/home/kevin/foo/src/core.clj:5)
```

and instead of waiting for a user-supplied ):

```
CompilerException java.lang.RuntimeException: EOF while reading, starting at line 6, compiling:(/home/kevin/foo/src/core.clj:7)
```
