### PR TITLE
Haskell REPL with cabal-dev support

### DIFF
--- a/config/Haskell/Main.sublime-menu
+++ b/config/Haskell/Main.sublime-menu
@@ -13,9 +13,9 @@
                  "id": "repl_haskell",
                  "mnemonic": "h",
                  "args": {
-                    "type": "subprocess",
+                    "type": "sublime_haskell",
                     "encoding": "utf8",
-                    "cmd": ["ghc", "--interactive"],
+                    "cmd": ["ghci"],
                     "cwd": "$file_path",
                     "external_id": "haskell",
                     "syntax": "Packages/Haskell/Haskell.tmLanguage"

--- a/repls/__init__.py
+++ b/repls/__init__.py
@@ -4,3 +4,4 @@ import telnet_repl
 import sublimepython_repl
 import execnet_repl
 import powershell_repl
+import sublimehaskell_repl

--- a/repls/sublimehaskell_repl.py
+++ b/repls/sublimehaskell_repl.py
@@ -1,0 +1,35 @@
+import re
+import os
+import sublime
+import sublime_plugin
+
+import subprocess_repl
+
+def get_settings():
+    return sublime.load_settings("SublimeHaskell.sublime-settings")
+
+def get_setting(key, default=None):
+    "This should be used only from main thread"
+    # Get setting
+    return get_settings().get(key, default)
+
+def ghci_package_db():
+    dev = get_setting('use_cabal_dev')
+    box = get_setting('cabal_dev_sandbox')
+    if dev and box:
+        package_conf = (filter(lambda x: re.match('packages-(.*)\.conf', x), os.listdir(box)) + [None])[0]
+        if package_conf:
+            return os.path.join(box, package_conf)
+    return None
+
+def ghci_append_package_db(cmd):
+    package_conf = ghci_package_db()
+    if package_conf:
+        cmd.extend(['-package-db', package_conf])
+    return cmd
+
+class SublimeHaskellRepl(subprocess_repl.SubprocessRepl):
+    TYPE = "sublime_haskell"
+
+    def __init__(self, encoding = None, external_id = None, cmd_postfix = "\n", suppress_echo = False, cmd = None, env = None, cwd = None, extend_env = None, soft_quit = "", autocomplete_server = False):
+        super(SublimeHaskellRepl, self).__init__(encoding, external_id, cmd_postfix, suppress_echo, ghci_append_package_db(cmd), env, cwd, extend_env, soft_quit, autocomplete_server)


### PR DESCRIPTION
I've implemented simple 'GHCi' command in SublimeHaskell, which loads GHCi on cabal or cabal-dev (depends on SublimeHaskell's settings). This setting is widely used in SublimeHaskell and can't be moved anywhere else.

But this command don't work with LoadFileToREPL, which uses default SublimeREPL command to open repl.

'GHCi' command from SublimeHaskell just calls repl_open with all the same args except 'cmd', which is ['ghci', '-package-db', path_to_package_conf] for cabal-dev and ['ghci'] otherwise, where path_to_package_conf depends on SublimeHaskell's setting.

I think, it'll be good, if SublimeREPL will try to load SublimeHaskell's settings and use them.

This pull request implements such command, but I don't know if it's a good solution.
