### PR TITLE
Fixes typo "CoffeScript"

### DIFF
--- a/config/CoffeeScript/Default.sublime-commands
+++ b/config/CoffeeScript/Default.sublime-commands
@@ -1,6 +1,6 @@
 [
     {
-        "caption": "SublimeREPL: CoffeScript",
+        "caption": "SublimeREPL: CoffeeScript",
         "command": "run_existing_window_command", "args":
         {
             "id": "repl_coffeescript",


### PR DESCRIPTION
Fixes a rather visible typo ("CoffeScript" in the command palette)
                                  ^
