### PR TITLE
fix a Scheme config bug introduced by commit 906cd87

### DIFF
--- a/config/Scheme/Default.sublime-commands
+++ b/config/Scheme/Default.sublime-commands
@@ -23,5 +23,4 @@
             "file": "config/Scheme/Main.sublime-menu"
         }
     }
-    }
 ]


### PR DESCRIPTION
there is a double curly bracket which makes JSON config parser unhappy
