### PR TITLE
Replaced uses of long() in sublimerepl.py with int()

### DIFF
--- a/sublimerepl.py
+++ b/sublimerepl.py
@@ -34,12 +34,12 @@ SETTINGS_FILE = 'SublimeREPL.sublime-settings'
 
 class ReplInsertTextCommand(sublime_plugin.TextCommand):
     def run(self, edit, pos, text):
-        self.view.insert(edit, long(pos), text)
+        self.view.insert(edit, int(pos), text)
 
 
 class ReplEraseTextCommand(sublime_plugin.TextCommand):
     def run(self, edit, start, end):
-        self.view.erase(edit, sublime.Region(long(start), long(end)))
+        self.view.erase(edit, sublime.Region(int(start), int(end)))
 
 
 class Event:


### PR DESCRIPTION
The latest commit broke ST3 compatibility for me. After a bit of digging, turns out that `long()` apparently no longer exists in Python3; `int()` should be used instead.
