### PR TITLE
Update pattern for chcp_encoding detection for PowerShellRepl

### DIFF
--- a/repls/powershell_repl.py
+++ b/repls/powershell_repl.py
@@ -31,7 +31,7 @@ class PowershellRepl(subprocess_repl.SubprocessRepl):
         if not encoding:
             # Detect encoding
             chcp = os.popen('chcp')
-            chcp_encoding = re.match(r'[^\d]+(\d+)$', chcp.read())
+            chcp_encoding = re.match(r'[^\d]+(\d+)', chcp.read())
             if not chcp_encoding:
                 raise LookupError("Can't detect encoding from chcp")
             encoding = "cp" + chcp_encoding.groups()[0]


### PR DESCRIPTION
I got the error "Can't detect encoding from chcp" on my Win7 64bit German
  C:\Dropbox\c\my> chcp 65001
  Aktive Codepage: 65001.
RegEx Pattern was changed to capture this
