### PR TITLE
Fix AttributeError in update_view_loop

### DIFF
--- a/sublimerepl.py
+++ b/sublimerepl.py
@@ -365,8 +365,9 @@ class ReplView(object):
             self._view.set_read_only(True)
             if sublime.load_settings(SETTINGS_FILE).get("view_auto_close"):
                 window = self._view.window()
-                window.focus_view(self._view)
-                window.run_command("close")
+                if window is not None:
+                    window.focus_view(self._view)
+                    window.run_command("close")
 
     def push_history(self, command):
         self._history.push(command)


### PR DESCRIPTION
```
AttributeError: 'NoneType' object has no attribute 'focus_view'
```

manually closing repl view with `view_auto_close` enabled.
`ReplView._view.window()` would be `None` in that case.
