### PR TITLE
Added some text massaging features to make the haskell repl easier to use

### DIFF
--- a/repls/sublimehaskell_repl.py
+++ b/repls/sublimehaskell_repl.py
@@ -27,21 +27,26 @@ def ghci_append_package_db(cmd):
         cmd.extend(['-package-db', package_conf])
     return cmd
 
-def removeWhitespace(lines):
+def ghci_remove_whitespace(lines):
     # remove lines that are completely whitespace
     lines = [line for line in lines if not line.isspace()]
     
     # remove extra whitespace for more flexible block execution        
-    lineSpaces = [len(line) - len(line.lstrip()) for line in lines]
-    minSpaces = min(lineSpaces)
-    fixedLines = [line[minSpaces:] for line in lines]
-    return fixedLines
+    line_spaces = [len(line) - len(line.lstrip()) for line in lines]
+    min_spaces = min(line_spaces)
+    fixed_lines = [line[min_spaces:] for line in lines]
+    return fixed_lines
 
-def wrapMultilineSyntax(lines):
-    # append mutli-line syntax if more than one line
-    lineLen = len(lines)
-    fixedLines = lines + [os.linesep] if lineLen == 1 else [":{" + os.linesep] + lines + [os.linesep + ":}" + os.linesep]
-    return fixedLines
+def ghci_wrap_multiline_syntax(lines):
+    # wrap in mutli-line syntax if more than one line
+    line_len = len(lines)
+    fixed_lines = lines[:]
+    if line_len == 1:
+        fixed_lines.append(os.linesep)
+    else:
+        fixed_lines.insert(0, ":{" + os.linesep)
+        fixed_lines.append(os.linesep + ":}" + os.linesep)
+    return fixed_lines
 
 class SublimeHaskellRepl(SubprocessRepl):
     TYPE = "sublime_haskell"
@@ -50,18 +55,17 @@ class SublimeHaskellRepl(SubprocessRepl):
         super(SublimeHaskellRepl, self).__init__(encoding, cmd=ghci_append_package_db(cmd), **kwds)
 
     def write(self, command):
-        setting_multiline = get_setting('format_multiline', False)
-        setting_trimwhitespace = get_setting('format_trim_whitespace', False)
+        setting_multiline = get_setting('format_multiline', True)
+        setting_trimwhitespace = get_setting('format_trim_whitespace', True)
         
-        newCmd = ""
+        new_cmd = ""
         if command.isspace() or (not setting_multiline and not setting_trimwhitespace):
-                newCmd = command
+                new_cmd = command
         else:
                 lines = command.splitlines(True)
                 if setting_trimwhitespace:
-                        lines = removeWhitespace(lines)
+                        lines = ghci_remove_whitespace(lines)
                 if setting_multiline:
-                        lines = wrapMultilineSyntax(lines)
-                newCmd = "".join(lines)
-
-	return super(HaskellRepl, self).write(newCmd)
+                        lines = ghci_wrap_multiline_syntax(lines)
+                new_cmd = "".join(lines)     
+        return super(HaskellRepl, self).write(new_cmd)


### PR DESCRIPTION
This commit contains two new options for the Haskell repl, both of which are off by default:
1) format_multiline which automatically wraps multiline text with :{ and :}
2) format_trim_whitespace which removes the lowest common number of whitespaces and empty lines in order to make block execution work well.
