### PR TITLE
Fix Python text_tranfer.

### DIFF
--- a/text_transfer.py
+++ b/text_transfer.py
@@ -31,7 +31,7 @@ def python_sender(repl, text, view=None):
     code = binascii.hexlify(text.encode("utf-8"))
     execute = ''.join([
         'from binascii import unhexlify as __un; exec(compile(__un("',
-        str(code),
+        str(code.decode('ascii')),
         '").decode("utf-8"), "<string>", "exec"))\n'
     ])
     return default_sender(repl, execute, view)


### PR DESCRIPTION
Python's text_transfer was missing quotes around the hex representation
of the portion of code to be executed. Due to this, it was impossible to
execute a portion of code from a file in the REPL.
