### PR TITLE
Small Change that I needed to get SublimeREPL working with F# on OSX - just wanted to share.

### DIFF
--- a/config/F/Main.sublime-menu
+++ b/config/F/Main.sublime-menu
@@ -18,7 +18,7 @@
                     "encoding": "utf8",
                     "cmd": {
                             "windows": ["fsi.exe", "--utf8output", "--gui-"],
-                            "osx": ["fsi", "--utf8output", "--readline-"],
+                            "osx": ["fsharpi", "--utf8output", "--readline-"],
                             "linux": ["fsi", "--utf8output", "--readline-"]},
                     "cwd": "$file_path",
                     "syntax": "Packages/F#/F#.tmLanguage" // http://code.google.com/p/fsharp-tmbundle/downloads/list


### PR DESCRIPTION
The mono command for F# interactive is fsharpi and NOT fsi as in the Microsoft distribution.
