### PR TITLE
SublimeHaskell Repl calling wrong superclass

### DIFF
--- a/repls/sublimehaskell_repl.py
+++ b/repls/sublimehaskell_repl.py
@@ -92,4 +92,4 @@ class SublimeHaskellRepl(SubprocessRepl):
                 if setting_multiline:
                         lines = ghci_wrap_multiline_syntax(lines)
                 new_cmd = "".join(lines)     
-        return super(HaskellRepl, self).write(new_cmd)
+        return super(SublimeHaskellRepl, self).write(new_cmd)


### PR DESCRIPTION
Code called wrong superclass

This fixes what seems to be a typo in sublimehaskell_repl.py.
