### PR TITLE
Remove trailing comma before closing bracket

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -2,5 +2,5 @@
     {
         "caption": "SublimeREPL: Restart REPL",
         "command": "repl_restart"
-    },
+    }
 ]


### PR DESCRIPTION
Fixes the following error:

Error loading commands: Error trying to parse file: Trailing comma before closing bracket in C:\Users\Kim\AppData\Roaming\Sublime Text 2\Packages\SublimeREPL\Default.sublime-commands:6:1
