### PR TITLE
Starting REPL from Command Palette not working when path contains non ASCII characters on Windows 

### DIFF
--- a/run_existing_command.py
+++ b/run_existing_command.py
@@ -18,7 +18,7 @@ def plugin_loaded():
 
 PY2 = False
 if sys.version_info[0] == 2:
-    SUBLIMEREPL_DIR = os.getcwd()
+    SUBLIMEREPL_DIR = os.getcwdu()
     SUBLIMEREPL_USER_DIR = os.path.join(sublime.packages_path(), "User", "SublimeREPL")
     PY2 = True
 


### PR DESCRIPTION
Sets SUBLIMEREPL_DIR with a Unicode object representing the current working directory.

The problem occurs on Windows, when the path to SublimeREPL package folder contains non ASCII characters (e.g. šćčž), and when we want through Command Palette (Ctrl+Shift+P) select the appropriate language to open REPL.
Error:
    Traceback (most recent call last):
    File ".\sublime_plugin.py", line 337, in run_
    File ".\run_existing_command.py", line 31, in run
    File ".\ntpath.py", line 108, in join
    UnicodeDecodeError: 'ascii' codec can't decode byte 0x8e in position 9: ordinal not in range(128)

In run_existing_command.py file, SUBLIMEREPL_DIR has been set by os.getcwd() which returns a string representing the current working directory.
Solution to the problem is to return Unicode object - os.getcwdu().
