### PR TITLE
F# config fixed

### DIFF
--- a/config/F/Main.sublime-menu
+++ b/config/F/Main.sublime-menu
@@ -21,7 +21,7 @@
                             "osx": ["fsharpi", "--utf8output", "--readline-"],
                             "linux": ["fsi", "--utf8output", "--readline-"]},
                     "cwd": "$file_path",
-                    "syntax": "Packages/F#/F#.tmLanguage" // http://code.google.com/p/fsharp-tmbundle/downloads/list
+                    "syntax": "Packages/F#/F#.tmLanguage"
                     }
                 }
             ]   


### PR DESCRIPTION
After trying to run F# repl in SublimeText 2.0.2 I recieve this stacktrace:
Traceback (most recent call last):
  File ".\sublime_plugin.py", line 337, in run_
  File ".\run_existing_command.py", line 32, in run
  File ".\run_existing_command.py", line 41, in _find_cmd
  File ".\run_existing_command.py", line 53, in _find_cmd_in_file
  File ".\json__init__.py", line 307, in loads
  File ".\json\decoder.py", line 319, in decode
  File ".\json\decoder.py", line 336, in raw_decode
  File ".\json\scanner.py", line 55, in iterscan
  File ".\json\decoder.py", line 217, in JSONArray
  File ".\json\scanner.py", line 55, in iterscan
  File ".\json\decoder.py", line 183, in JSONObject
  File ".\json\scanner.py", line 55, in iterscan
  File ".\json\decoder.py", line 217, in JSONArray
  File ".\json\scanner.py", line 55, in iterscan
  File ".\json\decoder.py", line 183, in JSONObject
  File ".\json\scanner.py", line 55, in iterscan
  File ".\json\decoder.py", line 217, in JSONArray
  File ".\json\scanner.py", line 55, in iterscan
  File ".\json\decoder.py", line 183, in JSONObject
  File ".\json\scanner.py", line 55, in iterscan
  File ".\json\decoder.py", line 193, in JSONObject
ValueError: Expecting , delimiter: line 24 column 59 (char 862)

JSON grammar doesnt specified comment, so I deleted it. After that repl has successfully launched.
