### PR TITLE
Tweaked F# config to have usuable cmd_postfix (only tested on Win)

### DIFF
--- a/config/F/Main.sublime-menu
+++ b/config/F/Main.sublime-menu
@@ -20,6 +20,7 @@
                             "windows": ["fsi.exe", "--utf8output", "--gui-"],
                             "osx": ["fsharpi", "--utf8output", "--readline-"],
                             "linux": ["fsi", "--utf8output", "--readline-"]},
+                    "cmd_postfix": ";;\n",
                     "cwd": "$file_path",
                     "syntax": "Packages/F#/F#.tmLanguage"
                     }


### PR DESCRIPTION
With this fix, one can just press <RETURN> and have the input line properly evaluated. It also means the 'Send to REPL' functionality won't require a cumbersome two-step workflow.
