### PR TITLE
Added clojurescript.tmLanguage, and set external_id of ClojureScript REPLs to "clojurescript"

### DIFF
--- a/config/ClojureScript/Main.sublime-menu
+++ b/config/ClojureScript/Main.sublime-menu
@@ -25,7 +25,7 @@
                                 "linux": "$file_path",
                                 "osx": "$file_path"},
                         "syntax": "Packages/Clojure/Clojure.tmLanguage",
-                        "external_id": "clojure",
+                        "external_id": "clojurescript",
                         "extend_env": {"INSIDE_EMACS": "1"}
                         }
                     },
@@ -43,7 +43,7 @@
                                 "linux": "$file_path",
                                 "osx": "$file_path"},
                         "syntax": "Packages/Clojure/Clojure.tmLanguage",
-                        "external_id": "clojure",
+                        "external_id": "clojurescript",
                         "extend_env": {"INSIDE_EMACS": "1"}
                         }
                     }

--- a/config/ClojureScript/clojurescript.tmLanguage
+++ b/config/ClojureScript/clojurescript.tmLanguage
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>comment</key>
+    <string>ClojureScript</string>
+    <key>name</key>
+    <string>ClojureScript</string>
+    <key>fileTypes</key>
+    <array>
+        <string>cljs</string>
+    </array>
+    <key>patterns</key>
+    <array>
+        <dict>
+            <key>include</key>
+            <string>source.clojure</string>
+        </dict>
+    </array>
+    <key>scopeName</key>
+    <string>source.clojurescript</string>
+</dict>
+</plist>


### PR DESCRIPTION
This fixes #212 with regards to the ClojureScript REPLs not working. There were other concerns in #212 that this PR doesn't address.

The issue was that ClojureScript was simply using the built-in clojure.tmLanguage in Sublime, which meant they shared the same `external_id`. This unfortunately meant that any custom sender used to wrap REPL input before eval was going to be used for both ClojureScript and Clojure, which turned out to not be ideal.

@wuub's suggestion was to add simple clojurescript.tmLanguage into the `config/ClojureScript` so that the two languages no longer needed to share an `external_id`.

Tested locally, both Clojure REPLs and both ClojureScript REPLs seem to be working normally again.
