### PR TITLE
Corrected format string to support python 2.6 (< 2.7)

### DIFF
--- a/text_transfer.py
+++ b/text_transfer.py
@@ -107,7 +107,7 @@ class ReplViewWrite(sublime_plugin.TextCommand):
             rv.append_input_text(text)
             break  # send to first repl found
         else:
-            sublime.error_message("Cannot find REPL for '{}'".format(external_id))
+            sublime.error_message("Cannot find REPL for '{0}'".format(external_id))
 
 
 class ReplSend(sublime_plugin.TextCommand):


### PR DESCRIPTION
Corrected format string to support pyhton 2.6 (< 2.7). Current implementation only
supports python 2.7+.

> '{0}, {1}, {2}'.format('a', 'b', 'c')
> 'a, b, c'
> '{}, {}, {}'.format('a', 'b', 'c')  # 2.7+ only
> 'a, b, c'

Sublime Text 2.0.2 for Windows uses Python 2.6.5
