### PR TITLE
Add missing "external_id" for Shell REPL

### DIFF
--- a/config/Shell/Main.sublime-menu
+++ b/config/Shell/Main.sublime-menu
@@ -24,6 +24,7 @@
                     "cmd_postfix": "\n", 
                     "env": {},
                     "suppress_echo": true, 
+                    "external_id": "shell",
                     "syntax": "Packages/Text/Plain text.tmLanguage"
                     }
                 }


### PR DESCRIPTION
Wasn't possible to transfer text and/or evaluate it with the Shell REPL.
