### PR TITLE
Add virtualenv path documentation to index.rst.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -157,6 +157,16 @@ Python
 
 Both stock Python and Execnet integrations support virtualenv. Various ways to work with Python, including PDB and IPython, are supported.
 
+For virtualenv created environments to be discoverable by SublimeREPL they should be created or symlinked in one of the following:
+
+* ~/.virtualenvs default for `virtualenvwrapper`__
+* ~/.venvs default for `venv`__
+
+Alternatively, more paths can be added to "python_virtualenv_paths" in the SublimeREPL configuration file.
+
+__ https://bitbucket.org/dhellmann/virtualenvwrapper
+__ https://github.com/wuub/venv
+
 Documentation contributions from a Python specialist are welcome.
 
 Configuration


### PR DESCRIPTION
Some additional documentation could make virtualenv setup easier for users who use environments set up at the project level.
