### PR TITLE
Fix the invalid path of python virtualenv when using glob.

### DIFF
--- a/lang_integration.py
+++ b/lang_integration.py
@@ -78,7 +78,7 @@ def scan_for_virtualenvs(venv_paths):
     found_dirs = set()
     for venv_path in venv_paths:
         p = os.path.expanduser(venv_path)
-        pattern = os.path.join(p, "*", bin_dir, "activate_this.py")
+        pattern = os.path.join(p, bin_dir, "activate_this.py")
         found_dirs.update(list(map(os.path.dirname, glob.glob(pattern))))
     return sorted(found_dirs)
 


### PR DESCRIPTION
When I create a virtualenv, the `bin` folder is a child folder of a virtualenv.
Therefore, with the additional asterisk, `activate_this.py` won't be find by python glob.
