### PR TITLE
Bundler can be used in rails console

### DIFF
--- a/SublimeREPL.sublime-settings
+++ b/SublimeREPL.sublime-settings
@@ -3,6 +3,7 @@
 	// that should be visible for all subprocess repls launched within
 	// SublimeREPL. This is a very good place to add PATH extension
 	// once "PATH": "{PATH}:/home/username/mylocalinstalls/bin" or whatever
+	// Add "REPL_USE_RAILS_BUNDLER": true" to use bundler in pry rails console
 	"default_extend_env": {},
 
 	// Specify whether to move repls to a different Sublime Text group (frame)

--- a/config/Rails/pry_repl.rb
+++ b/config/Rails/pry_repl.rb
@@ -1,6 +1,19 @@
 # Simply merged `pry_repl.rb` from the Ruby REPL and - https://github.com/doitian/rails-console-pry
 
 require 'rubygems'
+
+use_rails_bundler = ENV["REPL_USE_RAILS_BUNDLER"] && !!(ENV["REPL_USE_RAILS_BUNDLER"].downcase =~ /^(true|t|yes|y|1)$/i)
+if use_rails_bundler
+    require 'bundler'
+    begin 
+        # Set up load paths for all bundled gems 
+        ENV["BUNDLE_GEMFILE"] = "Gemfile"
+        Bundler.setup 
+    rescue Bundler::GemNotFound 
+        raise RuntimeError, "Bundler couldn't find some gems.\n" + "Did you run `bundle install`?" 
+    end
+end
+
 gem 'pry'
 require 'pry'
 require 'thread'


### PR DESCRIPTION
I added a ENV config value to turn it on/off. It is OFF by default.
It does the same thing to execute "bundle exec pry" in a terminal window.

Tested in ubuntu 13.10 64 bits + Sublime Text 3.
