### PR TITLE
Increased timeout to fix autocomplete bug w/ SublimeCodeIntel

### DIFF
--- a/config/Python/ipy_repl.py
+++ b/config/Python/ipy_repl.py
@@ -90,7 +90,7 @@ def send_netstring(sock, msg):
 def complete(zmq_shell, req):
     kc = kernel_client(zmq_shell)
     msg_id = kc.shell_channel.complete(**req)
-    msg = kc.shell_channel.get_msg(timeout=0.5)
+    msg = kc.shell_channel.get_msg(timeout=10)
     if msg['parent_header']['msg_id'] == msg_id:
         return msg["content"]["matches"]
     return []


### PR DESCRIPTION
When using SublimeCodeIntel (and possibly other completion engines), there can be a delay between typing something and the suggested completion(s) showing up in the menu. For example, if the Python database hasn't completely indexed all of my `site-packages`, I could type:

``` python
import n
```

and wait for a period of time before the menu brings up `nose`, `numba`, `numexpr`, `numpy`, etc. When that period of time is greater than 0.5 seconds, the following tracebacks appear:

``` python
 Exception in thread Thread-6:
Traceback (most recent call last):
  File "C:\Users\mattdmo\AppData\Roaming\Sublime Text 3\Packages/SublimeREPL/config/Python/ipy_repl.py", line 104, in handle
    completions = complete(embedded_shell, req)
  File "C:\Users\mattdmo\AppData\Roaming\Sublime Text 3\Packages/SublimeREPL/config/Python/ipy_repl.py", line 93, in complete
    msg = kc.shell_channel.get_msg(timeout=0.1)
  File "c:\python33\lib\site-packages\IPython\kernel\blocking\channels.py", line 41, in get_msg
    return self._in_queue.get(block, timeout)
  File "c:\python33\lib\queue.py", line 175, in get
    raise Empty
queue.Empty

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "c:\python33\lib\threading.py", line 901, in _bootstrap_inner
    self.run()
  File "c:\python33\lib\threading.py", line 858, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\mattdmo\AppData\Roaming\Sublime Text 3\Packages/SublimeREPL/config/Python/ipy_repl.py", line 109, in handle
    send_netstring(s, b"[]")
  File "C:\Users\mattdmo\AppData\Roaming\Sublime Text 3\Packages/SublimeREPL/config/Python/ipy_repl.py", line 86, in send_netstring
    payload = b"".join([str(len(msg)).encode("ascii"), b':', msg.encode("utf-8"), b','])
AttributeError: 'bytes' object has no attribute 'encode'
```

Oftentimes this makes the REPL nearly unuseable, as all typing is slower and autocomplete doesn't work any more. Occasionally, `plugin_host` will crash as well, necessitating a restart of Sublime Text. I have observed this bug in both ST2 and ST3, across a number of versions, and on all three platforms, including several versions of Windows.

---

My proposed fix is to bump the timeout up to 10 seconds. This should give the completion engine plenty of time to do its indexing, but not so much time that if there really is a problem with the autocomplete (SublimeCodeIntel crashed, for example) the user isn't kept hanging forever. 

I don't know if you've heard of this from other users, but it has been (periodically) bugging the heck out of my for a long time. I also don't know if other REPLs aside from IPython may have this bug since Python is my main language.
