### PR TITLE
scope=block of "Eval in REPL" is misleading

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -110,6 +110,8 @@
 	{ "keys": ["shift+ctrl+,", "f"], "command": "repl_transfer_current", "args": {"scope": "file", "action":"view_write"}},
 	{ "keys": ["ctrl+,", "l"], "command": "repl_transfer_current", "args": {"scope": "lines"}},
 	{ "keys": ["shift+ctrl+,", "l"], "command": "repl_transfer_current", "args": {"scope": "lines", "action":"view_write"}},
+	{ "keys": ["ctrl+,", "e"], "command": "repl_transfer_current", "args": {"scope": "expression"}},
+	{ "keys": ["shift+ctrl+,", "e"], "command": "repl_transfer_current", "args": {"scope": "expression", "action":"view_write"}},
 	{ "keys": ["ctrl+,", "b"], "command": "repl_transfer_current", "args": {"scope": "block"}},
 	{ "keys": ["shift+ctrl+,", "b"], "command": "repl_transfer_current", "args": {"scope": "block", "action":"view_write"}}
  ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -130,6 +130,8 @@
 	{ "keys": ["shift+ctrl+,", "f"], "command": "repl_transfer_current", "args": {"scope": "file", "action":"view_write"}},
 	{ "keys": ["ctrl+,", "l"], "command": "repl_transfer_current", "args": {"scope": "lines"}},
 	{ "keys": ["shift+ctrl+,", "l"], "command": "repl_transfer_current", "args": {"scope": "lines", "action":"view_write"}},
+	{ "keys": ["ctrl+,", "e"], "command": "repl_transfer_current", "args": {"scope": "expression"}},
+	{ "keys": ["shift+ctrl+,", "e"], "command": "repl_transfer_current", "args": {"scope": "expression", "action":"view_write"}},
 	{ "keys": ["ctrl+,", "b"], "command": "repl_transfer_current", "args": {"scope": "block"}},
 	{ "keys": ["shift+ctrl+,", "b"], "command": "repl_transfer_current", "args": {"scope": "block", "action":"view_write"}}
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -104,6 +104,8 @@
 	{ "keys": ["shift+ctrl+,", "f"], "command": "repl_transfer_current", "args": {"scope": "file", "action":"view_write"}},
 	{ "keys": ["ctrl+,", "l"], "command": "repl_transfer_current", "args": {"scope": "lines"}},
 	{ "keys": ["shift+ctrl+,", "l"], "command": "repl_transfer_current", "args": {"scope": "lines", "action":"view_write"}},
+	{ "keys": ["ctrl+,", "e"], "command": "repl_transfer_current", "args": {"scope": "expression"}},
+	{ "keys": ["shift+ctrl+,", "e"], "command": "repl_transfer_current", "args": {"scope": "expression", "action":"view_write"}},
 	{ "keys": ["ctrl+,", "b"], "command": "repl_transfer_current", "args": {"scope": "block"}},
 	{ "keys": ["shift+ctrl+,", "b"], "command": "repl_transfer_current", "args": {"scope": "block", "action":"view_write"}}
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -14,6 +14,7 @@
                         {"caption": "Selection", "command": "repl_transfer_current", "args": {"scope": "selection"}},
                         {"caption": "File", "command": "repl_transfer_current", "args": {"scope": "file"}},
                         {"caption": "Lines", "command": "repl_transfer_current", "args": {"scope": "lines"}},
+                        {"caption": "Expression", "command": "repl_transfer_current", "args": {"scope": "expression"}},
                         {"caption": "Block", "command": "repl_transfer_current", "args": {"scope": "block"}}
                 ]},
                 {"caption": "Transfer to REPL",
@@ -22,6 +23,7 @@
                         {"caption": "Selection", "command": "repl_transfer_current", "args": {"scope": "selection", "action":"view_write"}},
                         {"caption": "File", "command": "repl_transfer_current", "args": {"scope": "file", "action":"view_write"}},
                         {"caption": "Lines", "command": "repl_transfer_current", "args": {"scope": "lines", "action":"view_write"}},
+                        {"caption": "Expression", "command": "repl_transfer_current", "args": {"scope": "expression", "action":"view_write"}},
                         {"caption": "Block", "command": "repl_transfer_current", "args": {"scope": "block", "action":"view_write"}}
                     ]
                 },

--- a/text_transfer.py
+++ b/text_transfer.py
@@ -159,6 +159,8 @@ class ReplTransferCurrent(sublime_plugin.TextCommand):
             text = self.selected_lines()
         elif scope == "function":
             text = self.selected_functions()
+        elif scope == "expression":
+            text = self.selected_expressions()
         elif scope == "block":
             text = self.selected_blocks()
         elif scope == "file":
@@ -175,7 +177,24 @@ class ReplTransferCurrent(sublime_plugin.TextCommand):
         return "".join(parts)
 
     def selected_blocks(self):
-        # TODO: Clojure only for now
+        # TODO: Lisp-family only for now
+        v = self.view
+        old_sel = list(v.sel())
+        v.run_command("expand_selection", {"to": "brackets"})
+
+        sel = []
+        while sel != list(v.sel()):
+            sel = list(v.sel())
+            v.run_command("expand_selection", {"to": "brackets"})
+
+        v.sel().clear()
+        for s in old_sel:
+            v.sel().add(s)
+
+        return "\n\n".join([v.substr(s) for s in sel])
+
+    def selected_expressions(self):
+        # TODO: Lisp-family only for now
         v = self.view
         strs = []
         old_sel = list(v.sel())


### PR DESCRIPTION
When I first saw "Block" in "Eval in REPL", I thought it would evaluate a `defn` which the cursor is in.

For example, this Clojure code is in a buffer:

``` clojure
(defn add [i j]
  (+ i j))
```

The cursor is on `i` or `j`, then "Eval in REPL" with scope=block sends only `(+ i j)`, not the whole `defn` code.

If this is an expected behavior, "Block" is misleading. "Expression" is appropriate for it.

And, I desires the real "Block" feature.

FYI: Seemingly, it supports only Clojure, but, obviously, it also works with other Lisp-family languages. I tried it with Common Lisp, and it worked in the same way as Clojure.

https://github.com/wuub/SublimeREPL/blob/master/text_transfer.py#L178
