### PR TITLE
Auto-detect Rails Directory

### DIFF
--- a/config/Rails/Main.sublime-menu
+++ b/config/Rails/Main.sublime-menu
@@ -3,7 +3,7 @@
         "id": "tools",
         "children":
         [{
-            "caption": "Rails",
+            "caption": "SublimeREPL",
             "mnemonic": "r",
             "id": "SublimeREPL",
             "children":

--- a/config/Rails/Main.sublime-menu
+++ b/config/Rails/Main.sublime-menu
@@ -28,7 +28,7 @@
                     "cwd":"$folder",
                     "cmd_postfix":"\n",
                     "autocomplete_server": true,
-                    "syntax": "Packages/Ruby/Ruby.tmLanguage"
+                    "syntax": "Packages/Rails/Ruby on Rails.tmLanguage"
                   }
                 }
             ]

--- a/config/Rails/Main.sublime-menu
+++ b/config/Rails/Main.sublime-menu
@@ -26,7 +26,7 @@
                              "osx": ["ruby", "${packages}/SublimeREPL/config/Rails/pry_repl.rb", "$editor"] },
                     "env": {},
                     "soft_quit":"\nexit\n",
-                    "cwd":"$folder",
+                    "cwd":"$file_path",
                     "cmd_postfix":"\n",
                     "autocomplete_server": true,
                     "syntax": "Packages/Rails/Ruby on Rails.tmLanguage"

--- a/config/Rails/Main.sublime-menu
+++ b/config/Rails/Main.sublime-menu
@@ -12,11 +12,12 @@
                  "command": "repl_open",
                  "caption": "Rails",
                  "id": "repl_rails",
-                 "external_id":"rails",
                  "mnemonic": "r",
                  "args":
                   {
                     "type": "subprocess",
+                    "external_id":       "ruby.rails",
+                    "additional_scopes": ["ruby"],
                     "encoding": {"windows": "$win_cmd_encoding",
                                  "linux": "utf-8",
                                  "osx": "utf-8"},

--- a/config/Rails/pry_repl.rb
+++ b/config/Rails/pry_repl.rb
@@ -52,7 +52,17 @@ def read_netstring(s)
     return msg
 end
 
+def rails_dir
+    rails_config = 'config.ru'
+    Pathname.new(Pathname.getwd).ascend do |dir|
+        return dir if File.exist?(File.join(dir, rails_config))
+    end
+    fail 'Failed to find Rails config'
+end
+
 ENV['RAILS_ENV'] = "development"
+
+Dir.chdir rails_dir
 
 APP_PATH = File.expand_path('config/application')
 require APP_PATH


### PR DESCRIPTION
The Rails REPL will fail to load if your rails project is in a subdirectory of the Sublime project folder. This fix will work its way up from the current file to find the rails directory.

Also fixes issues with the Rails REPL's scope and syntax highlighting
