### PR TITLE
Change Syntax to Plain for REPL output

### DIFF
--- a/config/Python/Main.sublime-menu
+++ b/config/Python/Main.sublime-menu
@@ -38,7 +38,7 @@
                         "encoding": "utf8",
                         "cmd": ["python", "-i", "-u", "-m", "pdb", "$file_basename"],
                         "cwd": "$file_path",
-                        "syntax": "Packages/Python/Python.tmLanguage",
+                        "syntax": "Packages/Text/Plain text.tmLanguage",
                         "external_id": "python",
                         "extend_env": {"PYTHONIOENCODING": "utf-8"}
                         }
@@ -52,7 +52,7 @@
                         "encoding": "utf8",
                         "cmd": ["python", "-u", "$file_basename"],
                         "cwd": "$file_path",
-                        "syntax": "Packages/Python/Python.tmLanguage",
+                        "syntax": "Packages/Text/Plain text.tmLanguage",
                         "external_id": "python",
                         "extend_env": {"PYTHONIOENCODING": "utf-8"}
                         }


### PR DESCRIPTION
This changes the syntax highlighting from Python to Plain Text in the case of Run file or (run file under debugger). Before the fix the output written to the _REPL_ window, which has it's view changed to look just like a terminal instead of IDLE, was colored oddly according to Python syntax, (which confused and frustrated my students making interactive text-based adventure games). 

In fact, it would be awesome if it were easier to set our own syntax files for the REPL output so we could make one that matched the interactive output of our little games.
