### PR TITLE
Change clojure command to use trampoline

### DIFF
--- a/config/Clojure/Main.sublime-menu
+++ b/config/Clojure/Main.sublime-menu
@@ -11,15 +11,15 @@
                 {"caption": "Clojure",
                  "id": "Clojure",
                  "children":[
-                    {"command": "repl_open", 
+                    {"command": "repl_open",
                      "caption": "Clojure",
                      "id": "repl_clojure",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
-                        "cmd": {"windows": ["lein.bat", "repl"],
-                                "linux": ["lein", "repl"],
-                                "osx":  ["lein", "repl"]},
+                        "cmd": {"windows": ["lein.bat", "trampoline", "run", "-m", "clojure.main"],
+                                "linux": ["lein", "trampoline", "run", "-m", "clojure.main"],
+                                "osx":  ["lein", "trampoline", "run", "-m", "clojure.main"]},
                         "soft_quit": "\n(. System exit 0)\n",
                         "cwd": {"windows":"c:/Clojure",
                                 "linux": "$file_path",
@@ -29,10 +29,10 @@
                         "extend_env": {"INSIDE_EMACS": "1"}
                         }
                     },
-                    {"command": "clojure_auto_telnet_repl", 
+                    {"command": "clojure_auto_telnet_repl",
                      "id": "repl_clojure_telnet",
                      "caption": "Clojure-Telnet"}]}
-            ]   
+            ]
         }]
     }
 ]


### PR DESCRIPTION
Fixes some problems people are experiencing in this issue: https://github.com/wuub/SublimeREPL/issues/299

I also found that using the trampoline command significantly speeds up the REPL's evaluation as it doesn't copy every single line to the repl and display it as it does it as the user here mentions: http://stackoverflow.com/questions/20835788/is-it-normal-to-have-really-slow-text-transfer-in-sublime-text-2-with-the-clojur
