### PR TITLE
use default config file when loading ipython

### DIFF
--- a/config/Python/ipy_repl.py
+++ b/config/Python/ipy_repl.py
@@ -24,11 +24,11 @@ if not IPYTHON:
     import code
     code.InteractiveConsole().interact()
 
-from IPython.config.loader import Config
+from IPython.terminal.ipapp import load_default_config
 
 editor = "subl -w"
 
-cfg = Config()
+cfg = load_default_config()
 cfg.InteractiveShell.use_readline = False
 cfg.InteractiveShell.autoindent = False
 cfg.InteractiveShell.colors = "NoColor"


### PR DESCRIPTION
options set in the users .ipython config files will propogate to sublimeREPL
