### PR TITLE
Minor change for getting SublimeREPL to work with F# on Linux

### DIFF
--- a/config/F/Main.sublime-menu
+++ b/config/F/Main.sublime-menu
@@ -19,7 +19,7 @@
                     "cmd": {
                             "windows": ["fsi.exe", "--utf8output", "--gui-"],
                             "osx": ["fsharpi", "--utf8output", "--readline-"],
-                            "linux": ["fsi", "--utf8output", "--readline-"]},
+                            "linux": ["fsharpi", "--utf8output", "--readline-"]},
                     "cmd_postfix": ";;\n",
                     "cwd": "$file_path",
                     "syntax": "Packages/F#/F#.tmLanguage"


### PR DESCRIPTION
The F# interactive binary for Mono is fsharpi instead of fsi. This is the same change as for pull request #188
