### PR TITLE
add full(er) knitr support reopens #165

### DIFF
--- a/config/R/Main.sublime-menu
+++ b/config/R/Main.sublime-menu
@@ -16,6 +16,8 @@
                     "type": "subprocess",
                     "external_id": "r",
                     "additional_scopes": ["tex.latex.knitr"],
+                    "additional_scopes": ["tex.latex.knitr.ing"],
+                    "additional_scopes": ["tex.latex.knitr.beamer.ing"],
                     "encoding": {
                         "windows": "$win_cmd_encoding",
                         "linux": "utf8",


### PR DESCRIPTION
The earlier fix for #165 does not work, as @mikheyev and others noted.
On an `_.Rnw_, especially with beamer class, this still doesn't work; needs more (above) additional scopes.

@dpmccabe suggested the fix for this, and I extended it to also cover the beamer class, which appears to need its own additional scope.
