### PR TITLE
Fix mnemonics

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -4,7 +4,7 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [

--- a/config/Clojure/Main.sublime-menu
+++ b/config/Clojure/Main.sublime-menu
@@ -4,7 +4,7 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [

--- a/config/ClojureScript/Main.sublime-menu
+++ b/config/ClojureScript/Main.sublime-menu
@@ -4,7 +4,7 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [

--- a/config/CoffeeScript/Main.sublime-menu
+++ b/config/CoffeeScript/Main.sublime-menu
@@ -4,7 +4,7 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [

--- a/config/CommonLisp/Main.sublime-menu
+++ b/config/CommonLisp/Main.sublime-menu
@@ -4,7 +4,7 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
@@ -15,7 +15,7 @@
                     {"command": "repl_open",
                      "caption": "Clozure CL",
                      "id": "repl_ccl",
-                     "mnemonic": "r",
+                     "mnemonic": "C",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
@@ -30,7 +30,7 @@
                     {"command": "repl_open",
                      "caption": "SBCL",
                      "id": "repl_sbcl",
-                     "mnemonic": "r",
+                     "mnemonic": "S",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
@@ -45,7 +45,7 @@
                     {"command": "repl_open",
                      "caption": "GNU Clisp",
                      "id": "repl_clisp",
-                     "mnemonic": "r",
+                     "mnemonic": "G",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
@@ -60,7 +60,7 @@
                     {"command": "repl_open",
                      "caption": "Allegro CL",
                      "id": "repl_allegro",
-                     "mnemonic": "r",
+                     "mnemonic": "A",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
@@ -75,7 +75,7 @@
                     {"command": "repl_open",
                      "caption": "ABCL",
                      "id": "repl_abcl",
-                     "mnemonic": "r",
+                     "mnemonic": "B",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
@@ -90,7 +90,7 @@
                     {"command": "repl_open",
                      "caption": "CMUCL",
                      "id": "repl_cmucl",
-                     "mnemonic": "r",
+                     "mnemonic": "M",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
@@ -105,7 +105,7 @@
                     {"command": "repl_open",
                      "caption": "ECL",
                      "id": "repl_ecl",
-                     "mnemonic": "r",
+                     "mnemonic": "E",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",

--- a/config/Elixir/Main.sublime-menu
+++ b/config/Elixir/Main.sublime-menu
@@ -4,7 +4,7 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [

--- a/config/Erlang/Main.sublime-menu
+++ b/config/Erlang/Main.sublime-menu
@@ -4,7 +4,7 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [

--- a/config/Execnet/Main.sublime-menu
+++ b/config/Execnet/Main.sublime-menu
@@ -4,7 +4,7 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children": [
                 {"caption": "Python",

--- a/config/F/Main.sublime-menu
+++ b/config/F/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open", 
                  "caption": "F#",
                  "id": "repl_f#",
-                 "mnemonic": "f",
+                 "mnemonic": "F",
                  "args": {
                     "type": "subprocess",
                     "external_id": "fsharp",

--- a/config/GDB/Main.sublime-menu
+++ b/config/GDB/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open",
                  "caption": "GDB",
                  "id": "repl_gdb",
-                 "mnemonic": "d",
+                 "mnemonic": "D",
                  "args": {
                     "type": "subprocess",
                     "encoding": "utf8",

--- a/config/Groovy/Main.sublime-menu
+++ b/config/Groovy/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open",
                  "id": "repl_groovy",
                  "caption": "Groovy",
-                 "mnemonic": "g",
+                 "mnemonic": "G",
                  "args": {
                     "type": "subprocess",
                     "encoding": "utf8",

--- a/config/Haskell/Main.sublime-menu
+++ b/config/Haskell/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open", 
                  "caption": "Haskell",
                  "id": "repl_haskell",
-                 "mnemonic": "h",
+                 "mnemonic": "H",
                  "args": {
                     "type": "sublime_haskell",
                     "encoding": "utf8",

--- a/config/Io/Main.sublime-menu
+++ b/config/Io/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open",
                  "caption": "Io",
                  "id": "repl_io",
-                 "mnemonic": "i",
+                 "mnemonic": "I",
                  "args": {
                     "type": "subprocess",
                     "encoding": "utf8",

--- a/config/Lua/Main.sublime-menu
+++ b/config/Lua/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open", 
                  "caption": "Lua",
                  "id": "repl_lua",
-                 "mnemonic": "l",
+                 "mnemonic": "L",
                  "args": {
                     "type": "subprocess",
                     "encoding": "utf8",

--- a/config/Main.sublime-menu.template
+++ b/config/Main.sublime-menu.template
@@ -4,11 +4,11 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
-                // {"command": "repl_open", 
+                // {"command": "repl_open",
                 //  "caption": "Command Caption in Menu",
                 //  "mnemonic": "m",
                 //  "args": {
@@ -19,11 +19,11 @@
                 //     "env": {}, // clean environment for subprocess repl
                 //     "extend_env": {}, // variables to be added to standard env
                 //     "cmd_postfix": "\n", // postfix that will be automatically added after a line in repl
-                //     "suppress_echo": false, // try to remove remote echo 
+                //     "suppress_echo": false, // try to remove remote echo
                 //     "syntax": "Packages/Text/Plain text.tmLanguage"
                 //     }
                 // },
-            ]   
+            ]
         }]
     }
 ]

--- a/config/Matlab/Main.sublime-menu
+++ b/config/Matlab/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open",
                  "caption": "Matlab",
                  "id": "repl_matlab",
-                 "mnemonic": "m",
+                 "mnemonic": "M",
                  "args": {
                     "type": "subprocess",
                     "encoding": "utf8",

--- a/config/Maxima/Main.sublime-menu
+++ b/config/Maxima/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open",
                  "caption": "Maxima",
                  "id": "repl_maxima",
-                 "mnemonic": "m",
+                 "mnemonic": "M",
                   "args": {
                     "type": "subprocess",
                     "encoding": "utf8",

--- a/config/MozRepl/Main.sublime-menu
+++ b/config/MozRepl/Main.sublime-menu
@@ -4,13 +4,13 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open", 
                  "caption": "MozRepl",
-                 "mnemonic": "m",
+                 "mnemonic": "M",
                  "id": "repl_mozrepl",
                  "args": {
                     "type": "telnet",

--- a/config/NodeJS/Main.sublime-menu
+++ b/config/NodeJS/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open",
                  "caption": "Node",
                  "id": "repl_node",
-                 "mnemonic": "n",
+                 "mnemonic": "N",
                  "args": {
                     "type": "subprocess",
                     "encoding": "utf8",

--- a/config/OCaml/Main.sublime-menu
+++ b/config/OCaml/Main.sublime-menu
@@ -4,7 +4,7 @@
     "children":[
       {
         "caption":"SublimeREPL",
-        "mnemonic":"r",
+        "mnemonic":"R",
         "id":"SublimeREPL",
         "children":[
           {
@@ -14,7 +14,7 @@
                 "command":"repl_open",
                 "caption":"OCaml toplevel",
                 "id":"repl_ocaml",
-                "mnemonic":"r",
+                "mnemonic":"t",
                 "args":{
                   "type":"subprocess",
                   "external_id":"ocaml",
@@ -41,7 +41,7 @@
                 "command":"repl_open",
                 "caption":"OCaml utop",
                 "id":"repl_ocaml_utop",
-                "mnemonic":"r",
+                "mnemonic":"u",
                 "args":{
                   "type":"sublime_utop",
                   "external_id":"ocaml",

--- a/config/Octave/Main.sublime-menu
+++ b/config/Octave/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open",
                  "caption": "Octave",
                  "id": "repl_octave",
-                 "mnemonic": "o",
+                 "mnemonic": "O",
                  "args": {
                     "type": "subprocess",
                     "encoding": "utf8",

--- a/config/PHP/Main.sublime-menu
+++ b/config/PHP/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open", 
                  "caption": "PHP",
                  "id": "repl_php",
-                 "mnemonic": "s",
+                 "mnemonic": "P",
                  "args": {
                     "type": "subprocess",
                     "encoding": {"windows": "$win_cmd_encoding",

--- a/config/Perl/Main.sublime-menu
+++ b/config/Perl/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open", 
                  "caption": "Perl",
                  "id": "repl_Perl",
-                 "mnemonic": "p",
+                 "mnemonic": "P",
                  "args": {
                     "type": "subprocess",
                     "encoding": "utf8",

--- a/config/PowerShell/Main.sublime-menu
+++ b/config/PowerShell/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open", 
                  "caption": "PowerShell",
                  "id": "repl_powershell",
-                 "mnemonic": "p",
+                 "mnemonic": "P",
                  "args": {
                     "type": "powershell",
                     "encoding": "",

--- a/config/Prolog/Main.sublime-menu
+++ b/config/Prolog/Main.sublime-menu
@@ -11,7 +11,7 @@
             "caption":"Prolog (Sicstus)",
             "command":"repl_open",
             "id":"repl_prolog",
-            "mnemonic":"p",
+            "mnemonic":"P",
             "args":{
               "type":"subprocess",
               "external_id":"prolog",

--- a/config/Python/Main.sublime-menu
+++ b/config/Python/Main.sublime-menu
@@ -4,7 +4,7 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
@@ -15,7 +15,7 @@
                     {"command": "repl_open",
                      "caption": "Python",
                      "id": "repl_python",
-                     "mnemonic": "p",
+                     "mnemonic": "P",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
@@ -32,7 +32,7 @@
                     {"command": "repl_open",
                      "caption": "Python - PDB current file",
                      "id": "repl_python_pdb",
-                     "mnemonic": "d",
+                     "mnemonic": "D",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
@@ -46,7 +46,7 @@
                     {"command": "repl_open",
                      "caption": "Python - RUN current file",
                      "id": "repl_python_run",
-                     "mnemonic": "d",
+                     "mnemonic": "R",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
@@ -60,7 +60,7 @@
                     {"command": "repl_open",
                      "caption": "Python - IPython",
                      "id": "repl_python_ipython",
-                     "mnemonic": "p",
+                     "mnemonic": "I",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",

--- a/config/R/Main.sublime-menu
+++ b/config/R/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open",
                  "caption": "R",
                  "id": "repl_r",
-                 "mnemonic": "r",
+                 "mnemonic": "R",
                  "args": {
                     "type": "subprocess",
                     "external_id": "r",

--- a/config/Racket/Main.sublime-menu
+++ b/config/Racket/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children": [
             {
                 "caption": "SublimeREPL",
-                "mnemonic": "r",
+                "mnemonic": "R",
                 "id": "SublimeREPL",
                 "children": [
                     {
                         "command": "repl_open",
                         "caption": "Racket",
                         "id": "repl_plt_racket",
-                        "mnemonic": "n",
+                        "mnemonic": "R",
                         "args": {
                             "type": "subprocess",
                             "encoding": "utf8",

--- a/config/Rails/Main.sublime-menu
+++ b/config/Rails/Main.sublime-menu
@@ -4,7 +4,7 @@
         "children":
         [{
             "caption": "Rails",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
@@ -13,7 +13,7 @@
                  "caption": "Rails",
                  "id": "repl_rails",
                  "external_id":"rails",
-                 "mnemonic": "r",
+                 "mnemonic": "R",
                  "args":
                   {
                     "type": "subprocess",

--- a/config/Ruby/Main.sublime-menu
+++ b/config/Ruby/Main.sublime-menu
@@ -4,7 +4,7 @@
     "children":[
       {
         "caption":"SublimeREPL",
-        "mnemonic":"r",
+        "mnemonic":"R",
         "id":"SublimeREPL",
         "children":[
           {
@@ -14,7 +14,7 @@
                 "command":"repl_open",
                 "caption":"Ruby",
                 "id":"repl_ruby",
-                "mnemonic":"r",
+                "mnemonic":"R",
                 "args":{
                   "type":"subprocess",
                   "external_id":"ruby",
@@ -47,7 +47,7 @@
                 "command":"repl_open",
                 "caption":"Ruby - IRB (deprecated)",
                 "id":"repl_ruby_irb",
-                "mnemonic":"r",
+                "mnemonic":"I",
                 "args":{
                   "type":"subprocess",
                   "external_id":"ruby",

--- a/config/SML/Main.sublime-menu
+++ b/config/SML/Main.sublime-menu
@@ -4,7 +4,7 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [

--- a/config/Scala/Main.sublime-menu
+++ b/config/Scala/Main.sublime-menu
@@ -4,7 +4,7 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
@@ -36,7 +36,7 @@
                     {"command": "repl_open",
                      "caption": "SBT for opened folder",
                      "id": "repl_sbt",
-                     "mnemonic": "b",
+                     "mnemonic": "B",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",

--- a/config/Scheme/Main.sublime-menu
+++ b/config/Scheme/Main.sublime-menu
@@ -4,7 +4,7 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
@@ -15,7 +15,7 @@
                     {"command": "repl_open",
                      "caption": "Scheme",
                      "id": "repl_scheme",
-                     "mnemonic": "r",
+                     "mnemonic": "S",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
@@ -33,7 +33,7 @@
                     {"command": "repl_open",
                      "caption": "Gauche",
                      "id": "repl_gauche",
-                     "mnemonic": "r",
+                     "mnemonic": "G",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
@@ -51,7 +51,7 @@
                     {"command": "repl_open",
                      "caption": "Petite Chez Scheme",
                      "id": "repl_petite",
-                     "mnemonic": "r",
+                     "mnemonic": "P",
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",

--- a/config/ScriptCS/Main.sublime-menu
+++ b/config/ScriptCS/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open",
                  "caption": "ScriptCS",
                  "id": "repl_scriptcs",
-                 "mnemonic": "scs",
+                 "mnemonic": "C",
                  "args": {
                     "type": "subprocess",
                     "external_id": "scriptcs",

--- a/config/Shell/Main.sublime-menu
+++ b/config/Shell/Main.sublime-menu
@@ -4,14 +4,14 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [
                 {"command": "repl_open", 
                  "caption": "Shell",
                  "id": "repl_shell",
-                 "mnemonic": "s",
+                 "mnemonic": "S",
                  "args": {
                     "type": "subprocess",
                     "encoding": {"windows": "$win_cmd_encoding",

--- a/config/Sublime/Main.sublime-menu
+++ b/config/Sublime/Main.sublime-menu
@@ -4,7 +4,7 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [

--- a/config/Tower/Main.sublime-menu
+++ b/config/Tower/Main.sublime-menu
@@ -4,7 +4,7 @@
         "children":
         [{
             "caption": "SublimeREPL",
-            "mnemonic": "r",
+            "mnemonic": "R",
             "id": "SublimeREPL",
             "children":
             [

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -276,14 +276,14 @@ The menu configuration file `config/Lua/Menu.sublime-menu` contains::
           "children":
           [{
               "caption": "SublimeREPL",
-              "mnemonic": "r",
+              "mnemonic": "R",
               "id": "SublimeREPL",
               "children":
               [
                   {"command": "repl_open", 
                    "caption": "Lua",
                    "id": "repl_lua",
-                   "mnemonic": "l",
+                   "mnemonic": "L",
                    "args": {
                       "type": "subprocess",
                       "encoding": "utf8",


### PR DESCRIPTION
ST 3068 started printing these as errors in the console, which
was REALLY annoying since they would get printed whenever a change in
some cached file occured (e.g. tmLanguage was updated).

And by **really annoying** I mean so annyoing that I had to disable this package and re-enable everytime I would like to use it.

I don't know why github shows that I changed so many lines in some files, I explicitly only staged changes to the mnemonics because the files did not have trailing whitespace stripped and my ST is set to remove them automatically.

Edit: You are actually aware of this already: http://www.sublimetext.com/forum/viewtopic.php?f=2&t=17503&start=20#p65564