### PR TITLE
Set prompt to a default value

### DIFF
--- a/config/NodeJS/repl.js
+++ b/config/NodeJS/repl.js
@@ -3,7 +3,7 @@
     var repl = require('repl');
 
     var rep = repl.start({
-        prompt:    null, //'> ',
+        prompt:    '> ',
         source:    null, //process.stdin,
         eval:      null, //require('vm').runInThisContext,
         useGlobal: true, //false


### PR DESCRIPTION
node 0.12+ requires prompt to be set, otherwise it will throw `stringToWrite must be a string`

Fixes issue #404 
