### PR TITLE
Fix IPython 4 auto-complete

### DIFF
--- a/config/Python/ipy_repl.py
+++ b/config/Python/ipy_repl.py
@@ -89,8 +89,14 @@ def send_netstring(sock, msg):
 
 def complete(zmq_shell, req):
     kc = kernel_client(zmq_shell)
-    msg_id = kc.shell_channel.complete(**req)
-    msg = kc.shell_channel.get_msg(timeout=10)
+    # IPython 4+
+    if version > 3:
+        msg_id = kc.complete(req['line'], req['cursor_pos'])
+    # Ipython 1-3
+    else:
+        msg_id = kc.shell_channel.complete(**req)
+    
+    msg = kc.shell_channel.get_msg(timeout=0.5)
     if msg['parent_header']['msg_id'] == msg_id:
         return msg["content"]["matches"]
     return []


### PR DESCRIPTION
Thanks to brianhuey who made IPython 4 working in pull request: https://github.com/wuub/SublimeREPL/pull/440

Here I further fix the auto complete function for IPython 4. The bug was caused by the `kc.shell_channel.complete()` function has been changed into `kc.complete()` with different parameters in IPython 4.

After this, users should be able to use the latest IPython 4 instead of IPython 2 in sublimeREPL. This has been discussed in multiple open issues and can now be closed.
