### PR TITLE
add support for haskell.bird source type via additional_scopes

### DIFF
--- a/config/Haskell/Main.sublime-menu
+++ b/config/Haskell/Main.sublime-menu
@@ -18,6 +18,7 @@
                     "cmd": ["ghci"],
                     "cwd": "$file_path",
                     "external_id": "haskell",
+                    "additional_scopes": ["haskell.bird"],
                     "syntax": "Packages/Haskell/Haskell.tmLanguage"
                     }
                 }


### PR DESCRIPTION
Adds an additional_scope for the Haskell config so you can access the Haskell repl from an editor with Literate Haskell Bird Style syntax selected.
