### PR TITLE
fix nodejs repl start

### DIFF
--- a/config/NodeJS/repl.js
+++ b/config/NodeJS/repl.js
@@ -3,7 +3,7 @@
     var repl = require('repl');
 
     var rep = repl.start({
-        prompt:    null, //'> ',
+        prompt:    '> ', //null,
         source:    null, //process.stdin,
         eval:      null, //require('vm').runInThisContext,
         useGlobal: true, //false


### PR DESCRIPTION
fixes #364 so it can be finally closed after 2 years. 

On the final note: REPL is the most awesome sublime package, autocomplete in nodejs console makes me shit rainbows, but how on earth do you guys miss fixing such easy issues? Does it make sense to spend weeks developing something and scary-off 50% of the potential users with an unstartable repl?