### PR TITLE
Launch virtualenv directly

### DIFF
--- a/lang_integration.py
+++ b/lang_integration.py
@@ -93,8 +93,13 @@ class PythonVirtualenvRepl(sublime_plugin.WindowCommand):
             return
         (name, directory) = choices[index]
         activate_file = os.path.join(directory, "activate_this.py")
-        python_executable = os.path.join(directory, "python")
+        ipy = any(os.path.exists(python_executable[:-6]+ipy) for ipy in ["ipython", "ipython.exe"])
+        python_executable = os.path.join(directory, "ipython" if ipy else "python")
         path_separator = ":"
+        if ipy:
+            python_cmdline = [python_executable, "-i"]
+        else:
+            python_cmdline = [python_executable, "-i", "-u"]
         if os.name == "nt":
             python_executable += ".exe"  # ;-)
             path_separator = ";"
@@ -103,13 +108,11 @@ class PythonVirtualenvRepl(sublime_plugin.WindowCommand):
             {
                 "encoding":"utf8",
                 "type": "subprocess",
-                "autocomplete_server": True,
                 "extend_env": {
                     "PATH": directory + path_separator + "{PATH}",
-                    "SUBLIMEREPL_ACTIVATE_THIS": activate_file,
                     "PYTHONIOENCODING": "utf-8"
                 },
-                "cmd": [python_executable, "-u", "${packages}/SublimeREPL/config/Python/ipy_repl.py"],
+                "cmd": python_cmdline,
                 "cwd": "$file_path",
                 "encoding": "utf8",
                 "syntax": "Packages/Python/Python.tmLanguage",

--- a/lang_integration.py
+++ b/lang_integration.py
@@ -93,7 +93,7 @@ class PythonVirtualenvRepl(sublime_plugin.WindowCommand):
             return
         (name, directory) = choices[index]
         activate_file = os.path.join(directory, "activate_this.py")
-        ipy = any(os.path.exists(python_executable[:-6]+ipy) for ipy in ["ipython", "ipython.exe"])
+        ipy = any(os.path.exists(os.path.join(directory, ipy)) for ipy in ["ipython", "ipython.exe"])
         python_executable = os.path.join(directory, "ipython" if ipy else "python")
         path_separator = ":"
         if os.name == "nt":

--- a/lang_integration.py
+++ b/lang_integration.py
@@ -96,13 +96,13 @@ class PythonVirtualenvRepl(sublime_plugin.WindowCommand):
         ipy = any(os.path.exists(python_executable[:-6]+ipy) for ipy in ["ipython", "ipython.exe"])
         python_executable = os.path.join(directory, "ipython" if ipy else "python")
         path_separator = ":"
+        if os.name == "nt":
+            python_executable += ".exe"  # ;-)
+            path_separator = ";"
         if ipy:
             python_cmdline = [python_executable, "-i"]
         else:
             python_cmdline = [python_executable, "-i", "-u"]
-        if os.name == "nt":
-            python_executable += ".exe"  # ;-)
-            path_separator = ";"
 
         self.window.run_command("repl_open",
             {


### PR DESCRIPTION
I encountered several problems launching virtualenv in REPL. After read through the source I've found that it launch interactive shell from lines of code, in `ipy_repl.py`. This caused two problems:

- `sys.path` will not correctly include an empty string according to [documentation](https://docs.python.org/3/library/sys.html?highlight=sys.path#sys.path), therefore can't search for module in the current working directory.
- ~~up and down arrow key for command history will not work unless the cursor is in the last line.~~ (work well after tested again)

Is that piece of work a little bit redundant? I'm confusing of what bugs it solves comparing to the bugs it brings.

My environment: OSX 10.11 with latest dev build of Sublime