### PR TITLE
[Fix] warning: mnemonic h not found in menu caption Haskell

### DIFF
--- a/config/Haskell/Main.sublime-menu
+++ b/config/Haskell/Main.sublime-menu
@@ -3,7 +3,7 @@
     "children":
     [{
         "caption": "SublimeREPL",
-        "mnemonic": "r",
+        "mnemonic": "R",
         "id": "SublimeREPL",
         "children":
         [{
@@ -15,7 +15,7 @@
                 "command": "repl_open",
                 "caption": "Haskell",
                 "id": "repl_haskell",
-                "mnemonic": "h",
+                "mnemonic": "H",
                 "args": {
                     "type": "sublime_haskell",
                     "encoding": "utf8",
@@ -30,7 +30,7 @@
                 "command": "repl_open",
                 "caption": "Haskell - RUN Current file",
                 "id": "repl_haskell_run",
-                "mnemonic": "r",
+                "mnemonic": "R",
                 "args": {
                     "type": "sublime_haskell",
                     "encoding": "utf8",


### PR DESCRIPTION
### 1. Behavior before pull request

I keep getting unexpected warning message in Sublime Text console:

```python
warning: mnemonic h not found in menu caption Haskell
```

Example:

```python
generating syntax summary
warning: mnemonic h not found in menu caption Haskell
generating meta info summary
reloading settings Packages/User/Preferences.sublime-settings
warning: mnemonic h not found in menu caption Haskell
reloading /D/Sublime Text Build 3126 x64 For Debug/Data/Packages/User/Preferences.sublime-settings
reloading settings Packages/User/Preferences.sublime-settings
warning: mnemonic h not found in menu caption Haskell
command: drag_select {"event": {"button": 1, "x": 710.5, "y": 734.5}}
```

### 2. Behavior after pull request

I don't get warnings in Sublime Text console. Mnemonics works for me:

![Mnemonics](http://i.imgur.com/fxx3mC2.png)

### 3. Argumentation

Unexpected messages in Sublime Text console interfere with the debugging process.

See also similar [**pull request**](https://github.com/wuub/SublimeREPL/commit/c9649b7d2e87dffc71ffd7bbae1ab246c1b86df1).

### 4. Testing Environment

**Operating system and version:**
Windows 10 Enterprise LTSB 64-bit EN
**Sublime Text:**
Build 3126
**SublimeREPL:**
Last dev version of `merges` branch

Thanks.