### PR TITLE
Update Shell REPL, suppress unnecessary output + Disable unsupported child menus

### DIFF
--- a/config/Shell/Main.sublime-menu
+++ b/config/Shell/Main.sublime-menu
@@ -13,7 +13,7 @@
                  "id": "repl_shell",
                  "mnemonic": "S",
                  "args": {
-                    "type": "subprocess",
+                    "type": "sublime_shell",
                     "encoding": {"windows": "$win_cmd_encoding",
                                  "linux": "utf-8",
                                  "osx": "utf-8"},

--- a/repls/__init__.py
+++ b/repls/__init__.py
@@ -6,3 +6,4 @@ from .sublimepython_repl import *
 from .powershell_repl import *
 from .sublimeutop_repl import *
 # from .execnet_repl import *  # disabled for now
+from .sublimeshell_repl import *

--- a/repls/sublimeshell_repl.py
+++ b/repls/sublimeshell_repl.py
@@ -1,0 +1,40 @@
+import re
+
+from .subprocess_repl import SubprocessRepl
+
+class SublimeShellRepl(SubprocessRepl):
+    TYPE = "sublime_shell"
+
+    def __init__(self, encoding, cmd=None, **kwds):
+        super(SublimeShellRepl, self).__init__(encoding, cmd=cmd, **kwds)
+
+    def read(self):
+        while True:
+            bs = self.read_bytes()
+            if not bs:
+                return None
+
+            try:
+                # when opening Shell REPL -> errors are shown because the bash is not running in TTY
+                # and therefore the terminal process group cannot be set:
+                #       bash: cannot set terminal process group (10552): Inappropriate ioctl for device
+                #       bash: no job control in this shell
+                # This will surpress these errors
+                bs = re.sub(b'bash:(.*?)(device|shell)\n', b'', bs)
+
+                # Odd behaviour observed with the Primary Prompt String (PS1) of the bash
+                # It contains PS1 twice and some hex cahracters at the begin/end of the first one \x1b and \x07
+                #       b'\x1b]0;user@hostname: ~/.config/sublime-text-3/Packages/SublimeREPL/repls\x07user@hostname:~/.config/sublime-text-3/Packages/SublimeREPL/repls$ '    
+                #Unfortunately I failed to find the reason for this behavior :( but the below regex substitution will )
+                # remove the the first PS1 with the bex characters displaying just the standard PS1
+                bs = re.sub(b"\x1b.*\x07", b'', bs)
+
+                output = self.decoder.decode(bs)
+            except Exception as e:
+                output = "■"
+                self.reset_decoder()
+
+            if output:
+                return output
+
+

--- a/sublimerepl.py
+++ b/sublimerepl.py
@@ -610,6 +610,31 @@ class ReplOpenCommand(sublime_plugin.WindowCommand):
     def run(self, encoding, type, syntax=None, view_id=None, **kwds):
         manager.open(self.window, encoding, type, syntax, view_id, **kwds)
 
+    # The menu entry should only be enabled if the command is also available
+    # on the OS, otherwise the code will respond with errors later on
+    def is_enabled(self, **kwds):
+        # if only check if a command has been set
+        # otherwise the menu will always be enabled
+        if 'cmd' in kwds.keys():        
+            cmds = kwds['cmd']
+            cmd = ''
+
+            # different commmands for various platforms
+            if type(cmds) == dict:
+                if len(cmds.keys()) > 1:
+                    cmd = cmds[PLATFORM][0]
+                else:
+                    cmd = cmds[0]
+            elif type(cmds) == list:
+                cmd = cmds[0]
+
+            if cmd:
+                from shutil import which
+                if not which(cmd):
+                    return False
+
+        return True
+
 
 class ReplRestartCommand(sublime_plugin.TextCommand):
     def run(self, edit):


### PR DESCRIPTION
COMMIT 1:

I realized when opening a Shell REPL a bunch of unnecessary output and weird characters: 

```bash
bash: cannot set terminal process group (11708): Inappropriate ioctl for device
bash: no job control in this shell
]0;user@hostname: ~/.config/sublime-text-3/Packages/SublimeREPL/replsuser@hostname:~/.config/sublime-text-3/Packages/SublimeREPL/repls$
```

The bash errors seem to occur because the bash is not running in a TTY and can therefore no process group can be registered. The bash still works as expected but the output is not necessary and can be suppressed since this is not something that can be fixed anyhow (at least not to my knowledge). 
The first added regex will therefore filter these errors out so that they are not displayed angain. 

The actual Primary Prompt String (PS1) showed some very odd hex characters (\x1b, \x07) and in between I got a PS1 which doesn't quite fulfill the specs from the .bashrc file. After the \x07 the actual defined PS1 is written. Therefore,  the second regex will filter the odd hex characters and the PS1 in between them away.


COMMIT 2:
If programs are not installed on an OS and clicking the menu option for it will result in an error thrown when creating the Popen pipe.
To stop that from happening, the menu entries that are not currently supported by the OS should be disabled.