### PR TITLE
build_system_hack no longer breaks automatic build system, typing .exit to Node REPL closes the REPL session.

### DIFF
--- a/config/NodeJS/repl.js
+++ b/config/NodeJS/repl.js
@@ -35,4 +35,8 @@
         rep.rli.completer(inData.line, send);
     });
 
+    rep.on('exit', function() {
+        process.exit();
+    });
+
 })();

--- a/sublimerepl_build_system_hack.sublime-build
+++ b/sublimerepl_build_system_hack.sublime-build
@@ -1,5 +1,6 @@
 {
 	"target": "sublimerepl_build_system_hack",
+	"selector": "source.nothing",
 	"cmd": {
 		"file_path": "${file_path}",
 		"file": "${file}",


### PR DESCRIPTION
2 small improvements, so small I couldn't be bothered making 2 pull requests.