### PR TITLE
Add support for Clj REPL

### DIFF
--- a/config/Clojure/Default.sublime-commands
+++ b/config/Clojure/Default.sublime-commands
@@ -1,5 +1,13 @@
 [
     {
+        "caption": "SublimeREPL: Clj",
+        "command": "run_existing_window_command", "args":
+        {
+            "id": "repl_clj",
+            "file": "config/Clojure/Main.sublime-menu"
+        }
+    },
+    {
         "caption": "SublimeREPL: Clojure",
         "command": "run_existing_window_command", "args":
         {

--- a/config/Clojure/Main.sublime-menu
+++ b/config/Clojure/Main.sublime-menu
@@ -12,6 +12,24 @@
                  "id": "Clojure",
                  "children":[
                     {"command": "repl_open", 
+                     "caption": "Clj",
+                     "id": "repl_clj",
+                     "args": {
+                        "type": "subprocess",
+                        "encoding": "utf8",
+                        "cmd": {"windows": ["lein.bat", "repl"],
+                                "linux": ["lein", "repl"],
+                                "osx":  ["clj"]},
+                        "soft_quit": "\n(. System exit 0)\n",
+                        "cwd": {"windows":"c:/Clojure",
+                                "linux": "$file_path",
+                                "osx": "$folder"},
+                        "syntax": "Packages/Clojure/Clojure.tmLanguage",
+                        "external_id": "clojure",
+                        "extend_env": {"INSIDE_EMACS": "1"}
+                        }
+                    },
+                    {"command": "repl_open", 
                      "caption": "Clojure",
                      "id": "repl_clojure",
                      "args": {


### PR DESCRIPTION
Clojure recently released a new library, tools.deps.alpha, and an associated brew install package for Clojure that results in a new CLI and a wrapper script, "clj" to launch it. (See: https://clojure.org/guides/deps_and_cli)

This patch adds a third Clojure REPL option, "Clj".  This REPL has similar documentation needs to the existing lein REPL option - I'd be happy to contribute the docs for it as well, if this patch is accepted.