### PR TITLE
Fix DeprecationWarning: REPLServer.rli is deprecated

### DIFF
--- a/config/NodeJS/repl.js
+++ b/config/NodeJS/repl.js
@@ -3,7 +3,7 @@
     var repl = require('repl');
 
     var rep = repl.start({
-        prompt:    null, //'> ',
+        prompt:    '> ', //'> ',
         source:    null, //process.stdin,
         eval:      null, //require('vm').runInThisContext,
         useGlobal: true, //false
@@ -32,7 +32,7 @@
             var payload = msg.length + ":" + msg + ",";
             client.write(payload)
         }
-        rep.rli.completer(inData.line, send);
+        rep.completer(inData.line, send);
     });
 
 })();

--- a/config/Python/Main.sublime-menu
+++ b/config/Python/Main.sublime-menu
@@ -19,7 +19,7 @@
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
-                        "cmd": ["python", "-i", "-u"],
+                        "cmd": ["python3", "-i", "-u"],
                         "cwd": "$file_path",
                         "syntax": "Packages/Python/Python.tmLanguage",
                         "external_id": "python",
@@ -36,7 +36,7 @@
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
-                        "cmd": ["python", "-i", "-u", "-m", "pdb", "$file_basename"],
+                        "cmd": ["python3", "-i", "-u", "-m", "pdb", "$file_basename"],
                         "cwd": "$file_path",
                         "syntax": "Packages/Python/Python.tmLanguage",
                         "external_id": "python",
@@ -50,7 +50,7 @@
                      "args": {
                         "type": "subprocess",
                         "encoding": "utf8",
-                        "cmd": ["python", "-u", "$file_basename"],
+                        "cmd": ["python3", "-u", "$file_basename"],
                         "cwd": "$file_path",
                         "syntax": "Packages/Python/Python.tmLanguage",
                         "external_id": "python",
@@ -66,9 +66,9 @@
                         "encoding": "utf8",
                         "autocomplete_server": true,
                         "cmd": {
-                            "osx": ["python", "-u", "${packages}/SublimeREPL/config/Python/ipy_repl.py"],
-                            "linux": ["python", "-u", "${packages}/SublimeREPL/config/Python/ipy_repl.py"],
-                            "windows": ["python", "-u", "${packages}/SublimeREPL/config/Python/ipy_repl.py"]
+                            "osx": ["python3", "-u", "${packages}/SublimeREPL/config/Python/ipy_repl.py"],
+                            "linux": ["python3", "-u", "${packages}/SublimeREPL/config/Python/ipy_repl.py"],
+                            "windows": ["python3", "-u", "${packages}/SublimeREPL/config/Python/ipy_repl.py"]
                         },
                         "cwd": "$file_path",
                         "syntax": "Packages/Python/Python.tmLanguage",

--- a/config/Swift/Default.sublime-commands
+++ b/config/Swift/Default.sublime-commands
@@ -1,0 +1,10 @@
+[
+    {
+        "caption": "SublimeREPL: Swift",
+        "command": "run_existing_window_command",
+        "args": {
+            "id": "repl_swift",
+            "file": "config/Swift/Main.sublime-menu"
+        }
+    }
+]

--- a/config/Swift/Main.sublime-menu
+++ b/config/Swift/Main.sublime-menu
@@ -1,0 +1,29 @@
+[
+    {
+        "id": "tools",
+        "children":
+        [{
+            "caption": "SublimeREPL",
+            "mnemonic": "r",
+            "id": "SublimeREPL",
+            "children":
+            [
+                {"command": "repl_open",
+                 "caption": "Swift",
+                 "id": "repl_swift",
+                 "args": {
+                    "type": "subprocess",
+                    "external_id": "swift",
+                    "encoding": "utf8",
+                    "cmd": {
+                        "osx": ["swift"]
+                    },
+                    "cwd": "$file_path",
+                    "additional_scopes": ["swift"],
+                    "syntax": "Packages/Swift/Syntaxes/Swift.tmLanguage"
+                    }
+                }
+            ]
+        }]
+    }
+]


### PR DESCRIPTION
When I'm using replNode these days, it reports 'DeprecationWarning', so I removed `rli` in the node config file.