### PR TITLE
Make getenv_command slightly more robust

### DIFF
--- a/repls/subprocess_repl.py
+++ b/repls/subprocess_repl.py
@@ -143,7 +143,7 @@ class SubprocessRepl(Repl):
             try:
                 output = subprocess.check_output(getenv_command)
                 lines = output.decode("utf-8", errors="replace").splitlines()
-                env = dict(line.split('=', 1)  for line in lines)
+                env = dict(line.split('=', 1) for line in lines if '=' in line)
                 return env
             except:
                 import traceback


### PR DESCRIPTION
To help deal with an issue with getenv_command getting messed up with bash_complete or welcome messages in .bashrc/.bash_profile files I added a little conditional as suggested in this StackOverflow conversation:

* https://stackoverflow.com/a/38036933/4103586

This may not solve all situations, but it should protect against some of the more common scenarios.