### PR TITLE
docs: fix simple typo, rvews -> reviews

### DIFF
--- a/sublimerepl.py
+++ b/sublimerepl.py
@@ -464,7 +464,7 @@ class ReplManager(object):
         return rv
 
     def find_repl(self, external_id):
-        """Yields rvews matching external_id taken from source.[external_id] scope
+        """Yields reviews matching external_id taken from source.[external_id] scope
            Match is done on external_id value of repl and additional_scopes"""
         for rv in self.repl_views.values():
             if not (rv.repl and rv.repl.is_alive()):


### PR DESCRIPTION
There is a small typo in sublimerepl.py.

Should read `reviews` rather than `rvews`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md